### PR TITLE
Add R16B support.

### DIFF
--- a/replace_otp_vsn.sh
+++ b/replace_otp_vsn.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-find . -name rebar.config|xargs sed -i 's/require_otp_vsn,\s\+"\(.\+\)"/require_otp_vsn, "R15B03|R16B01|R16B02"/g'
+find . -name rebar.config|xargs sed -i 's/require_otp_vsn,\s\+"\(.\+\)"/require_otp_vsn, "R15B03|R16B|R16B01|R16B02"/g'


### PR DESCRIPTION
Currently R16B is not compiling since the required versions only lists R15B03 and R16B01. If there is no reason for specifically excluding R16B this patch simply adds it to the list.
