### PR TITLE
R16B addition

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
 %% under the License.
 %%
 %%======================================================================
-{require_otp_vsn, "R15B03|R16B01|R16B02"}.
+{require_otp_vsn, "R15B03|R16B|R16B01|R16B02"}.
 
 {deps, [
         {leo_manager, ".*", {git, "https://github.com/leo-project/leo_manager.git", {tag, "0.14.9"}}},


### PR DESCRIPTION
Minimal addition to the orignal pull request. Now the default rebar.config already includes the R16B entry so it is not necessary to run the gen
