### PR TITLE
Fixed typo in leo_storage smartos config file, closing issues 118

### DIFF
--- a/pkg/leo_storage/files/leo_storage.conf
+++ b/pkg/leo_storage/files/leo_storage.conf
@@ -125,7 +125,7 @@ log.ring_dir = /var/log/leo_storage/ring
 ## STORAGE - Other Directories
 ## --------------------------------------------------------------------
 ## Directory of queue for monitoring "RING"
-queue_dir  = /var/db/loe_storage/queue
+queue_dir  = /var/db/leo_storage/queue
 
 ## Directory of SNMP agent configuration
 ## snmp_agent = ./snmp/snmpa_storage_0/LEO-STORAGE


### PR DESCRIPTION
Fixing #118
