### PR TITLE
Fixed bug in SmartOS leo_manager makefile 

### DIFF
--- a/pkg/leo_manager/Makefile
+++ b/pkg/leo_manager/Makefile
@@ -9,6 +9,7 @@ STAGE_DIR=$(BASE)
 PKG_CATEGORY=leofs
 PKG_HOMEPAGE=http://www.leofs.org/
 DEPS="erlang>=16.1.2"
+TARGET_DIR=/opt/local
 
 include ../../deps/fifo_utils/priv/pkg.mk
 

--- a/pkg/leo_manager/pre_pkg
+++ b/pkg/leo_manager/pre_pkg
@@ -1,1 +1,0 @@
-@pkgdep erlang>=15.1.1


### PR DESCRIPTION
The makefile submitted did put the leo_manager into /opt/local/loe_manager/leo_manager, this patch corrects this and puts it into the propper place