### PR TITLE
There's a small bug in installation instruction about libatomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Then, install Erlang.
 ##
 $ wget http://www.hpl.hp.com/research/linux/atomic_ops/download/libatomic_ops-7.2d.tar.gz
 $ tar xzvf libatomic_ops-7.2d.tar.gz
-$ cd libatomic_ops-7.2d
+$ cd libatomic_ops-7.2
 $ ./configure --prefix=/usr/local
 $ make
 $ sudo make install


### PR DESCRIPTION
```
vagrant@vagrant-ubuntu-trusty-64:/tmp$ tar xzf libatomic_ops-7.2d.tar.gz
vagrant@vagrant-ubuntu-trusty-64:/tmp$ ls -l
total 232
drwxr-xr-x 6 vagrant vagrant   4096 Aug  9  2012 libatomic_ops-7.2
-rw-rw-r-- 1 vagrant vagrant 230358 Jun  9 20:26 libatomic_ops-7.2d.tar.gz
```