### PR TITLE
Fix missing argument for netcat

### DIFF
--- a/leofs-adm
+++ b/leofs-adm
@@ -69,6 +69,7 @@ case $OS in
     Linux)
         #  -q seconds   after EOF is detected, wait the specified number of seconds and then quit.
         NC_ARGS="-q 0"
+        ;;
     *)
         NC_ARGS="-C"
 esac

--- a/leofs-adm
+++ b/leofs-adm
@@ -66,6 +66,9 @@ case $OS in
     SunOS)
         NC_ARGS=""
         ;;
+    Linux)
+        #  -q seconds   after EOF is detected, wait the specified number of seconds and then quit.
+        NC_ARGS="-q 0"
     *)
         NC_ARGS="-C"
 esac


### PR DESCRIPTION
I tried leofs under ubuntu 16.04 and every call of leofs-adm failed, because nc is missing the EOF-quit-argument.
