### PR TITLE
manager: Fix delete_bucket for 1.3.x

### DIFF
--- a/apps/leo_manager/src/leo_manager_api.erl
+++ b/apps/leo_manager/src/leo_manager_api.erl
@@ -2282,7 +2282,7 @@ delete_bucket_1(AccessKeyBin, BucketBin) ->
                                       Node
                               end, Members),
             case rpc:multicall(Nodes, leo_storage_handler_directory,
-                               delete,
+                               delete_objects_in_parent_dir,
                                [BucketBin], ?DEF_TIMEOUT) of
                 {_, []} -> void;
                 {_, BadNodes} ->


### PR DESCRIPTION
## Description
Delete a bucket in LeoFS should also remove all the objects in it, but from 1.3.0, those objects are not removed. Creating a bucket with the same name and the file can then be easily accessed. A potential security problem.

## Related Issue
https://github.com/leo-project/leofs/issues/583