### PR TITLE
all: handle leofs-adm version all for #643

### DIFF
--- a/apps/leo_gateway/src/leo_gateway_api.erl
+++ b/apps/leo_gateway/src/leo_gateway_api.erl
@@ -37,6 +37,7 @@
 -export([get_node_status/0,
          register_in_monitor/1, register_in_monitor/2,
          purge/1, update_manager_nodes/1,
+         get_info/1,
          update_conf/2
         ]).
 

--- a/apps/leo_manager/include/leo_manager.hrl
+++ b/apps/leo_manager/include/leo_manager.hrl
@@ -313,6 +313,7 @@
 -define(ERROR_OVER_MAX_CLUSTERS, "Over max number of clusters").
 -define(ERROR_UPDATED_SYSTEM_CONF, "Updated the system configuration").
 -define(ERROR_FAILED_UPDATE_LOG_LEVEL, "Failed to update the log-level").
+-define(ERROR_FAILED_GET_VERSION, "Failed to get the version").
 
 %% type of console
 -define(CONSOLE_CUI, 'cui').

--- a/apps/leo_manager/src/leo_manager_console.erl
+++ b/apps/leo_manager/src/leo_manager_console.erl
@@ -77,6 +77,17 @@ handle_call(_Socket, <<?CMD_VERSION, ?LF>>, #state{formatter = Formatter} = Stat
 handle_call(_Socket, <<?CMD_VERSION, ?CRLF>>, #state{formatter = Formatter} = State) ->
     Reply = version(Formatter),
     {reply, Reply, State};
+handle_call(_Socket, <<?CMD_VERSION, ?SPACE, Option/binary>>, #state{formatter = Formatter} = State) ->
+    Fun = fun() ->
+                  case version_all(Option) of
+                      {ok, NodeList} ->
+                          Formatter:version_all(NodeList);
+                      {error, Cause} ->
+                          Formatter:error(Cause)
+                  end
+          end,
+    Reply = invoke(?CMD_VERSION, Formatter, Fun),
+    {reply, Reply, State};
 
 
 %% Command: "_user-id_"
@@ -1363,6 +1374,73 @@ version() ->
             {ok, []}
     end.
 
+%% @doc Retrieve version of every node in a cluster
+%% @private
+-spec(version_all(binary()) ->
+             {ok, list()} | {error, any()}).
+version_all(Option) ->
+    case ?get_tokens(Option, ?ERROR_INVALID_ARGS) of
+        {ok, ["all"|_]} ->
+            Master = atom_to_list(erlang:node()),
+            MasterVersion = case application:get_env(leo_manager, system_version) of
+                                {ok, Vsn} -> Vsn;
+                                undefined -> []
+                            end,
+            {Slave, SlaveVersion} = case ?env_partner_of_manager_node() of
+                                        [] ->
+                                            {"not_found", ?ERROR_FAILED_GET_VERSION};
+                                        [Partner|_] ->
+                                            case rpc:call(Partner, application, get_env, [leo_manager, system_version]) of
+                                                {badrpc, _} ->
+                                                    {atom_to_list(Partner), ?ERROR_FAILED_GET_VERSION};
+                                                {ok, SV} ->
+                                                    {atom_to_list(Partner), SV}
+                                            end
+                                    end,
+            Managers = [
+                        {"M", Master, MasterVersion},
+                        {"M", Slave, SlaveVersion}
+                       ],
+            Storages = case leo_manager_mnesia:get_storage_nodes_all() of
+                           {ok, R1} ->
+                               lists:map(fun(N) ->
+                                                 Node = N#node_state.node,
+                                                 V = case rpc:call(Node, leo_storage_api, get_info, [version]) of
+                                                         {badrpc, _} ->
+                                                             ?ERROR_FAILED_GET_VERSION;
+                                                         Res ->
+                                                             Res
+                                                     end,
+                                                 {?SERVER_TYPE_STORAGE,
+                                                  atom_to_list(Node),
+                                                  V}
+                                         end, R1);
+                           _ ->
+                               []
+                       end,
+            Gateways = case leo_manager_mnesia:get_gateway_nodes_all() of
+                           {ok, R2} ->
+                               lists:map(fun(N) ->
+                                                 Node = N#node_state.node,
+                                                 V = case rpc:call(Node, leo_gateway_api, get_info, [version]) of
+                                                         {badrpc, _} ->
+                                                             ?ERROR_FAILED_GET_VERSION;
+                                                         Res ->
+                                                             Res
+                                                     end,
+                                                 {?SERVER_TYPE_GATEWAY,
+                                                  atom_to_list(Node),
+                                                  V}
+                                         end, R2);
+                           _ ->
+                               []
+                       end,
+            {ok, Managers ++ Storages ++ Gateways};
+        {ok, _} ->
+            {error, ?ERROR_INVALID_ARGS};
+        Error ->
+            Error
+    end.
 
 %% @doc Exec login
 %% @private

--- a/apps/leo_manager/src/leo_manager_formatter_json.erl
+++ b/apps/leo_manager/src/leo_manager_formatter_json.erl
@@ -39,6 +39,7 @@
          acls/1, cluster_status/1,
          whereis/1, nfs_mnt_key/1,
          histories/1,
+         version_all/1,
          authorized/0, user_id/0, password/0
         ]).
 
@@ -180,6 +181,23 @@ system_info_and_nodes_stat(Props) ->
                {<<"node_list">>, NodeInfo}
               ]}).
 
+%% @doc Format a version list
+%%
+-spec(version_all([tuple()]) ->
+             binary()).
+version_all(Nodes) ->
+    NodeInfo = case Nodes of
+                   [] -> [];
+                   _  ->
+                       lists:map(
+                         fun({Type, NodeName, Version}) ->
+                                 {[{<<"type">>,      leo_misc:any_to_binary(Type)},
+                                   {<<"node">>,      leo_misc:any_to_binary(NodeName)},
+                                   {<<"version">>,   leo_misc:any_to_binary(Version)}
+                                  ]}
+                         end, Nodes)
+               end,
+    gen_json({[{<<"result">>, NodeInfo}]}).
 
 %% @doc Format a cluster node state
 %%

--- a/apps/leo_manager/src/leo_manager_formatter_text.erl
+++ b/apps/leo_manager/src/leo_manager_formatter_text.erl
@@ -39,6 +39,7 @@
          acls/1, cluster_status/1,
          whereis/1, nfs_mnt_key/1,
          histories/1,
+         version_all/1,
          authorized/0, user_id/0, password/0
         ]).
 
@@ -322,6 +323,53 @@ system_conf_with_node_stat(FormattedSystemConf, Nodes) ->
                        " [State of Node(s)]\r\n",
                        Header1,Header2, Header1], Nodes) ++ Header1 ++ ?CRLF.
 
+%% @doc Format the version of every node
+-spec(version_all(list()) ->
+             string()).
+version_all(Nodes) ->
+    Col_1_Len = lists:foldl(fun({_,N,_}, Acc) ->
+                                    Len = length(N),
+                                    case (Len > Acc) of
+                                        true  -> Len;
+                                        false -> Acc
+                                    end
+                            end, 0, Nodes) + 5,
+    CellColumns = [{"type", 6},
+                   {"node", Col_1_Len},
+                   {"version", 32},
+                   {'$end', 0}],
+    LenPerCol = lists:map(fun({_, Len}) -> Len end, CellColumns),
+
+
+    Fun1 = fun(Col, Str) ->
+                   case Col of
+                       {'$end',_Len      } -> lists:append([Str, ?CRLF]);
+                       {"type", Len      } -> lists:append([Str, lists:duplicate(Len + 1, "-"), "+"]);
+                       {"node", Len      } -> lists:append([Str, lists:duplicate(Len + 2, "-"), "+"]);
+                       {_Other, Len      } -> lists:append([Str, lists:duplicate(Len + 2, "-"), "+"])
+                   end
+           end,
+    Header1 = lists:foldl(Fun1, [], CellColumns),
+
+    Fun2 = fun(Col, Str) ->
+                   {Name, _} = Col,
+                   case Col of
+                       {'$end',_Len      } -> lists:append([Str, ?CRLF]);
+                       {_Other, Len      } -> lists:append([Str, string:centre(Name, Len, $ ), ?SEPARATOR])
+                   end
+           end,
+    Header2 = lists:foldl(Fun2, [], CellColumns),
+
+    Fun3 = fun(N, List) ->
+                   {Type, Alias, Version} = N,
+                   Ret = lists:append([string:centre(Type,    lists:nth(1,LenPerCol)), ?SEPARATOR,
+                                       string:left(Alias,     lists:nth(2,LenPerCol)), ?SEPARATOR,
+                                       string:left(Version,   lists:nth(3,LenPerCol)), ?SEPARATOR,
+                                       ?CRLF]),
+                   List ++ [Ret]
+           end,
+    lists:foldl(Fun3, [" [Version of Node(s)]\r\n",
+                       Header1,Header2, Header1], Nodes) ++ Header1 ++ ?CRLF.
 
 %% @doc Format a cluster node state
 -spec(node_stat(string(), [tuple()]) ->

--- a/apps/leo_storage/src/leo_storage_api.erl
+++ b/apps/leo_storage/src/leo_storage_api.erl
@@ -40,6 +40,7 @@
          get_node_status/0,
          rebalance/1, rebalance/3,
          get_disk_usage/0,
+         get_info/1,
          update_conf/2
         ]).
 -export([get_mq_consumer_state/0,

--- a/leofs-adm
+++ b/leofs-adm
@@ -887,7 +887,7 @@ usage() {
     output ""
     output "  LeoFS commands are:"
     output "      ${UNDERLINE}General Commands:${NONE}"
-    output "$WHITESPACE version"
+    output "$WHITESPACE version [all]"
     usage_status min
     usage_whereis min
     output ""
@@ -991,7 +991,7 @@ done
 
 case "$1" in
     version)
-        if [ $# -ne 1 ]; then
+        if [ $# -gt 2 ]; then
             echo "Usage: $SCRIPT version"
             exit 1
         fi


### PR DESCRIPTION
### text
```bash
$ ./leofs-adm version all
 [Version of Node(s)]
-------+--------------------------+----------------------------------+
 type  |           node           |             version              |
-------+--------------------------+----------------------------------+
  M    | manager_0@127.0.0.1      | 1.3.3                            |
  M    | manager_1@127.0.0.1      | 1.3.3                            |
  S    | storage_0@127.0.0.1      | 1.3.3                            |
  G    | gateway_0@127.0.0.1      | 1.3.3                            |
-------+--------------------------+----------------------------------+
```
### text with failed nodes
```bash
$ ./leofs-adm version all
 [Version of Node(s)]
-------+--------------------------+----------------------------------+
 type  |           node           |             version              |
-------+--------------------------+----------------------------------+
  M    | manager_0@127.0.0.1      | 1.3.3                            |
  M    | manager_1@127.0.0.1      | 1.3.3                            |
  S    | storage_0@127.0.0.1      | 1.3.3                            |
  G    | gateway_0@127.0.0.1      | Failed to get the version        |
-------+--------------------------+----------------------------------+
``` 

### json
```bash
$ ./leofs-adm version all|python -m json.tool
{
    "result": [
        {
            "node": "manager_0@127.0.0.1",
            "type": "M",
            "version": "1.3.3"
        },
        {
            "node": "manager_1@127.0.0.1",
            "type": "M",
            "version": "1.3.3"
        },
        {
            "node": "storage_0@127.0.0.1",
            "type": "S",
            "version": "1.3.3"
        },
        {
            "node": "gateway_0@127.0.0.1",
            "type": "G",
            "version": "1.3.3"
        }
    ]
}
```
### json with failed nodes
```bash
$ ./leofs-adm version all
./leofs-adm version all|python -m json.tool
{
    "result": [
        {
            "node": "manager_0@127.0.0.1",
            "type": "M",
            "version": "1.3.3"
        },
        {
            "node": "manager_1@127.0.0.1",
            "type": "M",
            "version": "1.3.3"
        },
        {
            "node": "storage_0@127.0.0.1",
            "type": "S",
            "version": "1.3.3"
        },
        {
            "node": "gateway_0@127.0.0.1",
            "type": "G",
            "version": "Failed to get the version"
        }
    ]
}
``` 