### PR TITLE
leofs: Add a comment about ERL_CRASH_DUMP_SECONDS for #667

### DIFF
--- a/rel/common/launch.sh
+++ b/rel/common/launch.sh
@@ -184,6 +184,13 @@ case "$1" in
 
         HEART_COMMAND="$RUNNER_BASE_DIR/bin/$SCRIPT start"
         export HEART_COMMAND
+
+        # Uncomment the below two lines ONLY if you face leo_(manager|storage|gateway) restarted frequently
+        # in order to dig down further for identifying the root cause.
+        # ERL_CRASH_DUMP_SECONDS=-1 means setting the environment variable to a negative value
+        # does not reboot the runtime system until the crash dump file is completely written.
+        ## ERL_CRASH_DUMP_SECONDS=-1
+        ## export ERL_CRASH_DUMP_SECONDS
         mkdir -p $PIPE_DIR
         shift # remove $1
         $ERTS_PATH/run_erl -daemon $PIPE_DIR $RUNNER_LOG_DIR "exec $RUNNER_BASE_DIR/bin/$SCRIPT console $@" 2>&1


### PR DESCRIPTION
I decided not to change the default behavior (not dumping a crash_dump) as it can be harmful to system as a core dump does.
Instead only add a comment about ERL_CRASH_DUMP_SECONDS notifying users when to uncomment those comments. 