### PR TITLE
Fix the output format of get-bucket command

### DIFF
--- a/apps/leo_manager/src/leo_manager_formatter_text.erl
+++ b/apps/leo_manager/src/leo_manager_formatter_text.erl
@@ -1077,7 +1077,7 @@ bucket_by_access_key(Buckets) ->
                              end
                             }
                     end, {Col_1_MinLen, Col_2_MinLen}, Buckets),
-    Col_3_Len = 24,
+    Col_3_Len = 28,
     Col_4_Len = 26,
     Header = lists:append(
                [string:left("bucket", Col_1_Len), " | ",

--- a/apps/leo_manager/src/leo_manager_formatter_text.erl
+++ b/apps/leo_manager/src/leo_manager_formatter_text.erl
@@ -1099,14 +1099,13 @@ bucket_by_access_key(Buckets) ->
                   BucketStr = binary_to_list(Bucket1),
                   PermissionsStr = leo_s3_bucket:aclinfo_to_str(Permissions1),
 
-                  RedOptions = leo_redundant_manager_api:get_options(),
+                  {ok, RedOptions} = leo_redundant_manager_api:get_options(),
                   ECParamsStr = get_redundancy_method_str(
                                   RedMethod, CPParams, ECParams, RedOptions),
                   Created2  = case (Created1 > 0) of
                                   true  -> leo_date:date_format(Created1);
                                   false -> []
                               end,
-
                   Acc ++ io_lib:format("~s | ~s | ~s | ~s\r\n",
                                        [string:left(BucketStr, Col_1_Len),
                                         string:left(PermissionsStr, Col_2_Len),


### PR DESCRIPTION
I've fixed the output format of get-bucket command for fixing #698 

```bash
$ ./leofs-adm get-bucket 05236
bucket   | permissions      | redundancy method            | created at
---------+------------------+------------------------------+---------------------------
test     | Me(full_control) | copy, {n:1, w:1, r:1, d:1}   | 2017-04-11 10:53:26 +0900

$ ./leofs-adm update-acl test 05236 public-read-write
OK

$ ./leofs-adm get-bucket 05236
bucket   | permissions                            | redundancy method            | created at
---------+----------------------------------------+------------------------------+---------------------------
test     | Me(full_control), Everyone(read,write) | copy, {n:1, w:1, r:1, d:1}   | 2017-04-11 10:53:26 +0900

$ ./leofs-adm get-buckets
cluster id   | bucket   | owner       | permissions                            | redundancy method            | created at
-------------+----------+-------------+----------------------------------------+------------------------------+---------------------------
leofs_1      | test     | _test_leofs | Me(full_control), Everyone(read,write) | copy, {n:1, w:1, r:1, d:1}   | 2017-04-11 10:53:26 +0900
```