### PR TITLE
manager: Fix leo-project/leofs/issues/698

### DIFF
--- a/apps/leo_manager/src/leo_manager_formatter_text.erl
+++ b/apps/leo_manager/src/leo_manager_formatter_text.erl
@@ -1077,7 +1077,7 @@ bucket_by_access_key(Buckets) ->
                              end
                             }
                     end, {Col_1_MinLen, Col_2_MinLen}, Buckets),
-    Col_3_Len = 24,
+    Col_3_Len = 28,
     Col_4_Len = 26,
     Header = lists:append(
                [string:left("bucket", Col_1_Len), " | ",


### PR DESCRIPTION
I've fixed the output format of get-bucket command for fixing #698 

```bash
$ ./leofs-adm get-bucket 05236
bucket   | permissions      | redundancy method            | created at
---------+------------------+------------------------------+---------------------------
test     | Me(full_control) | copy, {n:1, w:1, r:1, d:1}   | 2017-04-11 10:53:26 +0900

$ ./leofs-adm update-acl test 05236 public-read-write
OK

$ ./leofs-adm get-bucket 05236
bucket   | permissions                            | redundancy method            | created at
---------+----------------------------------------+------------------------------+---------------------------
test     | Me(full_control), Everyone(read,write) | copy, {n:1, w:1, r:1, d:1}   | 2017-04-11 10:53:26 +0900

$ ./leofs-adm get-buckets
cluster id   | bucket   | owner       | permissions                            | redundancy method            | created at
-------------+----------+-------------+----------------------------------------+------------------------------+---------------------------
leofs_1      | test     | _test_leofs | Me(full_control), Everyone(read,write) | copy, {n:1, w:1, r:1, d:1}   | 2017-04-11 10:53:26 +0900
```