### PR TITLE
manager: Fix leo_manager's part of leo-project/leofs/issues/645

### DIFF
--- a/apps/leo_manager/include/leo_manager.hrl
+++ b/apps/leo_manager/include/leo_manager.hrl
@@ -255,7 +255,7 @@
 -define(ERROR_NODE_NOT_EXISTS, "Node not exist").
 -define(ERROR_TABLE_NOT_EXISTS, "Tables not exist").
 -define(ERROR_FAILED_COMPACTION, "Failed compaction").
--define(ERROR_FAILED_GET_STORAGE_STATS, "Failed to get storage stats").
+%% -define(ERROR_FAILED_GET_STORAGE_STATS, "Failed to get storage stats").
 -define(ERROR_USER_NOT_FOUND, "User not found").
 -define(ERROR_COULD_NOT_GET_USER, "Could not get user(s)").
 -define(ERROR_COULD_NOT_ADD_USER, "Could not add a user").
@@ -294,9 +294,9 @@
 -define(ERROR_MNESIA_NOT_START, "Mnesia does not start, yet").
 -define(ERROR_NOT_SATISFY_CONDITION, "Not satisfy conditions").
 -define(ERROR_TARGET_NODE_NOT_RUNNING, "Target node does not running").
--define(ERROR_FAILED_BACKUP_MNESIA, "Failed to backup the mnesia backup file").
--define(ERROR_FAILED_RESTORE_MNESIA, "Failed to restore the mnesia backup file").
--define(ERROR_FAILED_UPDATE_MANAGERS, "Failed to update the manager nodes").
+%% -define(ERROR_FAILED_BACKUP_MNESIA, "Failed to backup the mnesia backup file").
+%% -define(ERROR_FAILED_RESTORE_MNESIA, "Failed to restore the mnesia backup file").
+%% -define(ERROR_FAILED_UPDATE_MANAGERS, "Failed to update the manager nodes").
 -define(ERROR_COULD_NOT_GET_CONF, "Could not get the system-config").
 -define(ERROR_MEMBER_NOT_FOUND, "Member not found").
 -define(ERROR_COULD_NOT_GET_MEMBER, "Could not get members (storage-nodes)").
@@ -410,10 +410,15 @@
 %% ---------------------------------------------------------
 %% MACROS
 %% ---------------------------------------------------------
+-define(MANAGER_TYPE_MASTER, 'master').
+-define(MANAGER_TYPE_SLAVE, 'slave').
+-type(manager_type() :: ?MANAGER_TYPE_MASTER |
+                        ?MANAGER_TYPE_SLAVE).
+
 -define(env_mode_of_manager(),
         case application:get_env(leo_manager, manager_mode) of
             {ok, EnvModeOfManager} -> EnvModeOfManager;
-            _ -> 'master'
+            _ -> ?MANAGER_TYPE_MASTER
         end).
 
 -define(env_partner_of_manager_node(),

--- a/apps/leo_manager/priv/leo_manager_0.conf
+++ b/apps/leo_manager/priv/leo_manager_0.conf
@@ -86,8 +86,24 @@ consistency.rack_aware_replicas = 0
 ## A number of replication targets
 ## mdc_replication.max_targets = 2
 
-## A number of replicas a DC
+## A number of replicas per a datacenter
+## [note] A local LeoFS sends a stacked object which contains an items of a replication method:
+##          - [L1_N] A number of replicas
+##          - [L1_W] A number of replicas needed for a successful WRITE operation
+##          - [L1_R] A number of replicas needed for a successful READ operation
+##          - [L1_D] A number of replicas needed for a successful DELETE operation
+##       A remote cluster of a LeoFS system which receives its object,
+##       and then replicates it by its contained reoplication method.
 ## mdc_replication.num_of_replicas_a_dc = 1
+
+## MDC replication / A number of replicas needed for a successful WRITE operation
+## mdc_replication.consistency.write = 1
+
+## MDC replication / A number of replicas needed for a successful READ operation
+## mdc_replication.consistency.read = 1
+
+## MDC replication / A number of replicas needed for a successful DELETE operation
+## mdc_replication.consistency.delete = 1
 
 
 ## --------------------------------------------------------------------

--- a/apps/leo_manager/priv/leo_manager_0.schema
+++ b/apps/leo_manager/priv/leo_manager_0.schema
@@ -247,9 +247,36 @@
   {default, 2}
  ]}.
 
-%% @doc A number of replicas a DC
+%% @doc A number of replicas per a DC
 {mapping,
  "mdc_replication.num_of_replicas_a_dc",
+ "leo_manager.system",
+ [
+  {datatype, integer},
+  {default, 1}
+ ]}.
+
+%% @doc  MDC replication / A number of replicas needed for a successful WRITE operation
+{mapping,
+ "mdc_replication.consistency.write",
+ "leo_manager.system",
+ [
+  {datatype, integer},
+  {default, 1}
+ ]}.
+
+%% @doc  MDC replication / A number of replicas needed for a successful READ operation
+{mapping,
+ "mdc_replication.consistency.read",
+ "leo_manager.system",
+ [
+  {datatype, integer},
+  {default, 1}
+ ]}.
+
+%% @doc  MDC replication / A number of replicas needed for a successful DELETE operation
+{mapping,
+ "mdc_replication.consistency.delete",
  "leo_manager.system",
  [
   {datatype, integer},
@@ -266,6 +293,9 @@
          R  = cuttlefish_util:conf_get_value("consistency.read", Conf),
          D  = cuttlefish_util:conf_get_value("consistency.delete", Conf),
          L1 = cuttlefish_util:conf_get_value("mdc_replication.num_of_replicas_a_dc", Conf),
+         L1_W = cuttlefish_util:conf_get_value("mdc_replication.consistency.write", Conf),
+         L1_R = cuttlefish_util:conf_get_value("mdc_replication.consistency.read", Conf),
+         L1_D = cuttlefish_util:conf_get_value("mdc_replication.consistency.delete", Conf),
          L2 = cuttlefish_util:conf_get_value("consistency.rack_aware_replicas", Conf),
          DC = cuttlefish_util:conf_get_value("mdc_replication.max_targets", Conf),
 
@@ -276,8 +306,11 @@
           {r, R},
           {d, D},
           {bit_of_ring, 128},
-          {max_mdc_targets,      DC},
-          {num_of_dc_replicas,   L1},
+          {max_mdc_targets,    DC},
+          {num_of_dc_replicas, L1},
+          {mdcr_w, L1_W},
+          {mdcr_r, L1_R},
+          {mdcr_d, L1_D},
           {num_of_rack_replicas, L2}
          ]
  end}.

--- a/apps/leo_manager/src/leo_manager_api.erl
+++ b/apps/leo_manager/src/leo_manager_api.erl
@@ -2,7 +2,7 @@
 %%
 %% Leo Manager
 %%
-%% Copyright (c) 2012-2015 Rakuten, Inc.
+%% Copyright (c) 2012-2017 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -107,9 +107,12 @@ load_system_config() ->
                      r = leo_misc:get_value(r, Props, 1),
                      d = leo_misc:get_value(d, Props, 1),
                      bit_of_ring = leo_misc:get_value(bit_of_ring, Props, 128),
-                     max_mdc_targets = leo_misc:get_value(max_mdc_targets, Props, 0),
-                     num_of_dc_replicas = leo_misc:get_value(num_of_dc_replicas, Props, 0),
-                     num_of_rack_replicas = leo_misc:get_value(num_of_rack_replicas, Props, 0)
+                     max_mdc_targets = leo_misc:get_value(max_mdc_targets, Props, 1),
+                     num_of_dc_replicas = leo_misc:get_value(num_of_dc_replicas, Props, 1),
+                     num_of_rack_replicas = leo_misc:get_value(num_of_rack_replicas, Props, 0),
+                     mdcr_r = leo_misc:get_value(mdcr_r, Props, 1),
+                     mdcr_w = leo_misc:get_value(mdcr_w, Props, 1),
+                     mdcr_d = leo_misc:get_value(mdcr_d, Props, 1)
                     },
     SystemConf.
 
@@ -129,7 +132,10 @@ load_system_config_with_store_data() ->
                   bit_of_ring = BitOfRing,
                   max_mdc_targets = MaxMDCTargets,
                   num_of_dc_replicas = NumOfDCReplicas,
-                  num_of_rack_replicas = NumOfRackReplicas
+                  num_of_rack_replicas = NumOfRackReplicas,
+                  mdcr_r = MDCR_R,
+                  mdcr_w = MDCR_W,
+                  mdcr_d = MDCR_D
                  } = SystemConf,
 
     %% Compare the current conf
@@ -157,7 +163,10 @@ load_system_config_with_store_data() ->
                                   bit_of_ring = BitOfRing,
                                   max_mdc_targets = MaxMDCTargets,
                                   num_of_dc_replicas = NumOfDCReplicas,
-                                  num_of_rack_replicas = NumOfRackReplicas}) of
+                                  num_of_rack_replicas = NumOfRackReplicas,
+                                  mdcr_r = MDCR_R,
+                                  mdcr_w = MDCR_W,
+                                  mdcr_d = MDCR_D}) of
                 ok ->
                     {ok, SystemConf};
                 Error ->
@@ -192,8 +201,6 @@ compare_system_conf([{K,V}|Rest], SystemConf) ->
 
 %% @doc Modify the system config
 %%      when it did not join remote-cluster(s), yet
-
-
 -spec(update_mdc_items_in_system_conf() ->
              ok | {error, any()}).
 update_mdc_items_in_system_conf() ->

--- a/apps/leo_manager/src/leo_manager_console.erl
+++ b/apps/leo_manager/src/leo_manager_console.erl
@@ -2,7 +2,7 @@
 %%
 %% Leo Manager
 %%
-%% Copyright (c) 2012-2015 Rakuten, Inc.
+%% Copyright (c) 2012-2017 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -1478,22 +1478,10 @@ get_status(Option) ->
 
     case (erlang:length(Token) == 0) of
         true ->
-            %% Reload and store system-conf
-            case ?env_mode_of_manager() of
-                'master' ->
-                    case leo_cluster_tbl_conf:get() of
-                        {ok, SystemConf} ->
-                            SystemConf;
-                        _ ->
-                            void
-                    end;
-                _ ->
-                    void
-            end,
-
-            %% Retrieve the status
+            %% Retrieve the state of the loacl cluster
             status(node_list);
         false ->
+            %% Retrieve the state of a specified node
             [Node|_] = Token,
             status({node_state, Node})
     end.
@@ -1503,8 +1491,10 @@ status(node_list) ->
     case leo_cluster_tbl_conf:get() of
         {ok, SystemConf} ->
             Version = case application:get_env(leo_manager, system_version) of
-                          {ok, Vsn} -> Vsn;
-                          undefined -> []
+                          {ok, Vsn} ->
+                              Vsn;
+                          undefined ->
+                              []
                       end,
             {ok, {RingHash0, RingHash1}} = leo_redundant_manager_api:checksum(ring),
 
@@ -1542,9 +1532,9 @@ status(node_list) ->
                          []
                  end,
             {ok, {node_list, [{system_config, SystemConf},
-                              {version,       Version},
-                              {ring_hash,     [RingHash0, RingHash1]},
-                              {nodes,         S1 ++ S2}
+                              {version, Version},
+                              {ring_hash, [RingHash0, RingHash1]},
+                              {nodes, S1 ++ S2}
                              ]}};
         {error, Cause} ->
             {error, Cause}

--- a/apps/leo_manager/src/leo_manager_formatter_json.erl
+++ b/apps/leo_manager/src/leo_manager_formatter_json.erl
@@ -2,7 +2,7 @@
 %%
 %% Leo Manager
 %%
-%% Copyright (c) 2012-2015 Rakuten, Inc.
+%% Copyright (c) 2012-2017 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -171,7 +171,12 @@ system_info_and_nodes_stat(Props) ->
                   {<<"r">>, SystemConf#?SYSTEM_CONF.r},
                   {<<"w">>, SystemConf#?SYSTEM_CONF.w},
                   {<<"d">>, SystemConf#?SYSTEM_CONF.d},
-                  {<<"dc_awareness_replicas">>,   SystemConf#?SYSTEM_CONF.num_of_dc_replicas},
+                  %% @Deprecated: `dc_awareness_replicas`
+                  {<<"dc_awareness_replicas">>, SystemConf#?SYSTEM_CONF.num_of_dc_replicas},
+                  {<<"mdcr_n">>, SystemConf#?SYSTEM_CONF.num_of_dc_replicas},
+                  {<<"mdcr_r">>, SystemConf#?SYSTEM_CONF.mdcr_r},
+                  {<<"mdcr_w">>, SystemConf#?SYSTEM_CONF.mdcr_w},
+                  {<<"mdcr_d">>, SystemConf#?SYSTEM_CONF.mdcr_d},
                   {<<"rack_awareness_replicas">>, SystemConf#?SYSTEM_CONF.num_of_rack_replicas},
                   {<<"ring_size">>,      SystemConf#?SYSTEM_CONF.bit_of_ring},
                   {<<"ring_hash_cur">>,  RH0},

--- a/apps/leo_manager/src/leo_manager_formatter_text.erl
+++ b/apps/leo_manager/src/leo_manager_formatter_text.erl
@@ -2,7 +2,7 @@
 %%
 %% Leo Manager
 %%
-%% Copyright (c) 2012-2015 Rakuten, Inc.
+%% Copyright (c) 2012-2017 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -211,6 +211,9 @@ system_info_and_nodes_stat(Props) ->
     %% [Multi DC replication settings]
     %%        # of destination of DCs : 0
     %%        # of replicas to a DC   : 0
+    %%       mdcr/# of successes of R : 1
+    %%       mdcr/# of successes of W : 2
+    %%       mdcr/# of successes of D : 1
     FormattedSystemConf =
         io_lib:format(lists:append([
                                     " [System Confiuration]\r\n",
@@ -231,8 +234,11 @@ system_info_and_nodes_stat(Props) ->
                                     "-----------------------------------+----------\r\n",
                                     " Multi DC replication settings\r\n",
                                     "-----------------------------------+----------\r\n",
-                                    "        max number of joinable DCs | ~w\r\n",
-                                    "           number of replicas a DC | ~w\r\n",
+                                    " [mdcr] max number of joinable DCs | ~w\r\n",
+                                    " [mdcr] total replicas per a DC    | ~w\r\n",
+                                    " [mdcr] number of successes of R   | ~w\r\n",
+                                    " [mdcr] number of successes of W   | ~w\r\n",
+                                    " [mdcr] number of successes of D   | ~w\r\n",
                                     "-----------------------------------+----------\r\n",
                                     " Manager RING hash\r\n",
                                     "-----------------------------------+----------\r\n",
@@ -251,13 +257,20 @@ system_info_and_nodes_stat(Props) ->
                        SystemConf#?SYSTEM_CONF.bit_of_ring,
                        SystemConf#?SYSTEM_CONF.max_mdc_targets,
                        SystemConf#?SYSTEM_CONF.num_of_dc_replicas,
+                       SystemConf#?SYSTEM_CONF.mdcr_r,
+                       SystemConf#?SYSTEM_CONF.mdcr_w,
+                       SystemConf#?SYSTEM_CONF.mdcr_d,
                        case (RH0 < 1) of
-                           true -> "";
-                           false -> leo_hex:integer_to_hex(RH0, 8)
+                           true ->
+                               [];
+                           false ->
+                               leo_hex:integer_to_hex(RH0, 8)
                        end,
                        case (RH1 < 1) of
-                           true -> "";
-                           false -> leo_hex:integer_to_hex(RH1, 8)
+                           true ->
+                               [];
+                           false ->
+                               leo_hex:integer_to_hex(RH1, 8)
                        end
                       ]),
     system_conf_with_node_stat(FormattedSystemConf, Nodes).

--- a/apps/leo_manager/src/leo_manager_transformer.erl
+++ b/apps/leo_manager/src/leo_manager_transformer.erl
@@ -57,8 +57,9 @@ transform() ->
 
     %% data migration - bucket
     case ?env_use_s3_api() of
-        false -> void;
-        true  ->
+        false ->
+            void;
+        true ->
             {ok, #?SYSTEM_CONF{cluster_id = ClusterId}} = leo_cluster_tbl_conf:get(),
             ok = leo_s3_bucket:transform(),
             ok = leo_s3_bucket:transform(ClusterId),


### PR DESCRIPTION
I've fixed leo_manager's part of leo-project/leofs/issues/645.
- Added MDC replication related configuration items on `leo_manager/priv/leo_manager_0.conf` as well as on the `CLI output (both text and json)`
- Implemented storing a consistency level and MDC-replication related items into leo_manager's database _(mnesia)_

### A result of `leofs-adm status`
```
$ leofs-adm status
 [System Confiuration]
-----------------------------------+----------
 Item                              | Value
-----------------------------------+----------
 Basic/Consistency level
-----------------------------------+----------
                    system version | 1.3.3
                        cluster Id | leofs_1
                             DC Id | dc_1
                    Total replicas | 3
          number of successes of R | 1
          number of successes of W | 2
          number of successes of D | 2
 number of rack-awareness replicas | 0
                         ring size | 2^128
-----------------------------------+----------
 Multi DC replication settings
-----------------------------------+----------
 [mdcr] max number of joinable DCs | 2
 [mdcr] total replicas per a DC    | 3
 [mdcr] number of successes of R   | 2
 [mdcr] number of successes of W   | 2
 [mdcr] number of successes of D   | 2
-----------------------------------+----------
 Manager RING hash
-----------------------------------+----------
                 current ring-hash | a08aab77
                previous ring-hash | a08aab77
-----------------------------------+----------

 [State of Node(s)]
-------+--------------------------+--------------+----------------+----------------+----------------------------
 type  |           node           |    state     |  current ring  |   prev ring    |          updated at
-------+--------------------------+--------------+----------------+----------------+----------------------------
  S    | storage_0@127.0.0.1      | running      | a08aab77       | a08aab77       | 2017-04-19 16:25:17 +0900
  S    | storage_1@127.0.0.1      | running      | a08aab77       | a08aab77       | 2017-04-19 16:25:16 +0900
  S    | storage_2@127.0.0.1      | running      | a08aab77       | a08aab77       | 2017-04-19 16:25:16 +0900
  S    | storage_3@127.0.0.1      | running      | a08aab77       | a08aab77       | 2017-04-19 16:25:16 +0900
  G    | gateway_0@127.0.0.1      | running      | a08aab77       | a08aab77       | 2017-04-19 16:25:30 +0900
-------+--------------------------+--------------+----------------+----------------+----------------------------
```