### PR TITLE
replace cuttlefish repo

### DIFF
--- a/apps/leo_gateway/rebar.config
+++ b/apps/leo_gateway/rebar.config
@@ -23,6 +23,7 @@
 {require_otp_vsn, "R16B*|17|18|19"}.
 
 {deps, [
+	{cuttlefish,            ".*", {git, "https://github.com/emqtt/cuttlefish",             		{branch, "develop"}}},
         {leo_cache,             ".*", {git, "https://github.com/leo-project/leo_cache.git",             {tag, "0.8.3"}}},
         {leo_commons,           ".*", {git, "https://github.com/leo-project/leo_commons.git",           {tag, "1.1.9"}}},
         {leo_logger,            ".*", {git, "https://github.com/leo-project/leo_logger.git",            {tag, "1.2.5"}}},


### PR DESCRIPTION
replace this cuttlefish repo, make leofs compile in erlang 19. See #724 .
This is still a try, need more works.