### PR TITLE
storage: Handle not_found to remove unnecessary messages of async-deletion

### DIFF
--- a/apps/leo_storage/src/leo_storage_mq.erl
+++ b/apps/leo_storage/src/leo_storage_mq.erl
@@ -352,6 +352,8 @@ handle_call({consume, ?QUEUE_ID_ASYNC_DELETION, MessageBin}) ->
                                  }, 0, false, leo_mq) of
                 ok ->
                     ok;
+                {error, not_found} ->
+                    ok;
                 {_, Cause} ->
                     {error, Cause}
             end;


### PR DESCRIPTION
To fix #732 