### PR TITLE
Modified for leo-project/leofs#761

### DIFF
--- a/apps/leo_gateway/rel/reltool.config
+++ b/apps/leo_gateway/rel/reltool.config
@@ -66,7 +66,6 @@
        %% LeoFS-related
        {app, leo_gateway,           [{incl_cond, include},{lib_dir, "../"}]},
        {app, bear,                  [{incl_cond, include}]},
-       {app, bitcask,               [{incl_cond, include}]},
        {app, cowboy,                [{incl_cond, include}]},
        {app, cowlib,                [{incl_cond, include}]},
        {app, elarm,                 [{incl_cond, include}]},

--- a/apps/leo_manager/priv/leo_manager_0.schema
+++ b/apps/leo_manager/priv/leo_manager_0.schema
@@ -526,7 +526,7 @@
  "leo_mq.backend_db",
  [
   {datatype, atom},
-  {default, 'bitcask'}
+  {default, 'leveldb'}
  ]}.
 
 %% @doc

--- a/apps/leo_manager/priv/leo_manager_1.schema
+++ b/apps/leo_manager/priv/leo_manager_1.schema
@@ -375,7 +375,7 @@
  "leo_mq.backend_db",
  [
   {datatype, atom},
-  {default, 'bitcask'}
+  {default, 'leveldb'}
  ]}.
 
 %% @doc

--- a/apps/leo_manager/rel/reltool.config
+++ b/apps/leo_manager/rel/reltool.config
@@ -58,7 +58,6 @@
        %% LeoFS-related
        {app, leo_manager,           [{incl_cond, include},{lib_dir, "../"}]},
        {app, bear,                  [{incl_cond, include}]},
-       {app, bitcask,               [{incl_cond, include}]},
        {app, eleveldb,              [{incl_cond, include}]},
        {app, folsom,                [{incl_cond, include}]},
        {app, jiffy,                 [{incl_cond, include}]},

--- a/apps/leo_storage/include/leo_storage.hrl
+++ b/apps/leo_storage/include/leo_storage.hrl
@@ -207,6 +207,35 @@
           key :: any(),
           timestamp = 0 :: non_neg_integer(),
           times = 0 :: non_neg_integer()}).
+-record(async_deletion_message_1, {
+          id = 0 :: non_neg_integer(),
+          addr_id = 0 :: non_neg_integer(),
+          key :: any(),
+          meta :: term(),
+          timestamp = 0 :: non_neg_integer(),
+          times = 0 :: non_neg_integer()}).
+-define(MSG_ASYNC_DELETION, 'async_deletion_message_1').
+-define(transform_async_deletion_message(_Msg),
+        begin
+            case _Msg of
+                #async_deletion_message{id = _Id,
+                                        addr_id = _AddrId,
+                                        key = _Key,
+                                        timestamp = _Timestamp,
+                                        times = _Time} ->
+                    {ok, #async_deletion_message_1{
+                            id = _Id,
+                            addr_id = _AddrId,
+                            key = _Key,
+                            timestamp = _Timestamp,
+                            times = _Time}};
+                #async_deletion_message_1{} ->
+                    {ok,_Msg};
+                _ ->
+                    {error, invalid_record}
+            end
+        end).
+
 
 -record(recovery_node_message, {
           id = 0 :: non_neg_integer(),

--- a/apps/leo_storage/priv/leo_storage.conf
+++ b/apps/leo_storage/priv/leo_storage.conf
@@ -59,7 +59,8 @@ obj_containers.num_of_containers = [8]
 ## Interval in ms of the data synchronization - default: 1000ms
 ## obj_containers.sync_interval_in_ms = 1000
 
-## Metadata Storage: [bitcask, leveldb] - default:leveldb
+## Metadata Storage:
+## NOTE: To be able to only use 'leveldb' from v1.3.5
 ## obj_containers.metadata_storage = leveldb
 
 ## A number of virtual-nodes for the redundant-manager
@@ -221,8 +222,9 @@ compaction.batch_procs_max = 1500
 ## --------------------------------------------------------------------
 ## STORAGE - MQ
 ## --------------------------------------------------------------------
-## MQ backend storage: [leveldb | bitcask] - default:leveldb
-mq.backend_db = leveldb
+## MQ backend storage
+## NOTE: To be able to only use 'leveldb' from v1.3.5
+## mq.backend_db = leveldb
 
 ## A number of mq-server's processes
 mq.num_of_mq_procs = 4

--- a/apps/leo_storage/priv/leo_storage.conf.test
+++ b/apps/leo_storage/priv/leo_storage.conf.test
@@ -139,14 +139,18 @@ leo_logger.profile = true
 
 ## Enable profiler - leo_mq
 leo_mq.profile = true
-## MQ backend storage: [bitcask, leveldb]
+
+## MQ backend storage
+## NOTE: To be able to only use 'leveldb' from v1.3.5
 leo_mq.backend_db = leveldb
 
 ## Enable profiler - leo_object_storage
 leo_object_storage.profile = true
 ## Enable strict check between checksum of a metadata and checksum of an object
 leo_object_storage.is_strict_check = true
-## Metadata Storage: [bitcask, leveldb]
+
+## Metadata Storage
+## NOTE: To be able to only use 'leveldb' from v1.3.5
 leo_object_storage.metadata_storage = leveldb
 
 ## Enable profiler - leo_ordning_reda

--- a/apps/leo_storage/rel/reltool.config
+++ b/apps/leo_storage/rel/reltool.config
@@ -61,7 +61,6 @@
        %% LeoFS-related
        {app, leo_storage,           [{incl_cond, include},{lib_dir, "../"}]},
        {app, bear,                  [{incl_cond, include}]},
-       {app, bitcask,               [{incl_cond, include}]},
        {app, elarm,                 [{incl_cond, include}]},
        {app, eleveldb,              [{incl_cond, include}]},
        {app, folsom,                [{incl_cond, include}]},

--- a/apps/leo_storage/src/leo_sync_local_cluster.erl
+++ b/apps/leo_storage/src/leo_sync_local_cluster.erl
@@ -254,9 +254,8 @@ slice_and_replicate_1(#?METADATA{addr_id = AddrId,
     case leo_storage_handler_object:head(AddrId, Key, false) of
         {ok, #?METADATA{clock = Clock_1}} when Clock == Clock_1 ->
             slice_and_replicate(StackedObject, Errors);
-        {ok, #?METADATA{clock = Clock_1}} when Clock < Clock_1 ->
-            ok = leo_storage_mq:publish(?QUEUE_ID_PER_OBJECT,
-                                        AddrId, Key, ?ERR_TYPE_REPLICATE_DATA),
+        {ok, #?METADATA{clock = Clock_1} = Metadata} when Clock < Clock_1 ->
+            ok = leo_storage_mq:publish(?QUEUE_ID_PER_OBJECT, Metadata, ?ERR_TYPE_REPLICATE_DATA),
             slice_and_replicate(StackedObject, Errors);
         _ ->
             case leo_misc:get_env(leo_redundant_manager, ?PROP_RING_HASH) of

--- a/apps/leo_storage/test/leo_storage_read_repairer_tests.erl
+++ b/apps/leo_storage/test/leo_storage_read_repairer_tests.erl
@@ -92,7 +92,7 @@ regular_({Test0Node, Test1Node}) ->
                                                                               end]),
     meck:new(leo_storage_mq, [non_strict]),
     meck:expect(leo_storage_mq, publish,
-                fun(_,_,_,_) ->
+                fun(_,_,_) ->
                         ok
                 end),
 
@@ -115,7 +115,7 @@ fail_1_({Test0Node, Test1Node}) ->
                                                                               end]),
     meck:new(leo_storage_mq, [non_strict]),
     meck:expect(leo_storage_mq, publish,
-                fun(_,_,_,_) ->
+                fun(_,_,_) ->
                         ok
                 end),
 
@@ -138,7 +138,7 @@ fail_2_({Test0Node, Test1Node}) ->
                                                                               end]),
     meck:new(leo_storage_mq, [non_strict]),
     meck:expect(leo_storage_mq, publish,
-                fun(_,_,_,_) ->
+                fun(_,_,_) ->
                         ok
                 end),
 

--- a/apps/leo_storage/test/leo_storage_replicator_tests.erl
+++ b/apps/leo_storage/test/leo_storage_replicator_tests.erl
@@ -155,10 +155,11 @@ replicate_obj_2_({Test0Node, Test1Node}) ->
 gen_mock_2(object, {_Test0Node, _Test1Node}, Case) ->
     meck:new(leo_storage_mq, [non_strict]),
     meck:expect(leo_storage_mq, publish,
-                fun(Type, VNodeId, Key, _ErrorType) ->
+                fun(Type,  #?METADATA{addr_id = AddrId,
+                                      key = Key} = Metadata, _ErrorType) ->
                         ?assertEqual(?QUEUE_ID_PER_OBJECT, Type),
-                        ?assertEqual(?TEST_RING_ID_1,        VNodeId),
-                        ?assertEqual(?TEST_KEY_1,            Key),
+                        ?assertEqual(?TEST_RING_ID_1, AddrId),
+                        ?assertEqual(?TEST_KEY_1, Key),
                         ok
                 end),
 


### PR DESCRIPTION
I've modified the all component to fix #761. We need to share data migration tool on the new documentation as below:

> We provide the `db-converter tool` - from `bitcask` to `leveldb` which is [leofs_utils/tools/b2l](https://github.com/leo-project/leofs_utils/tree/develop/tools/b2l).

