### PR TITLE
Fix deleted objects can be remained in case compare_between_metadatas return the error tuple

### DIFF
--- a/apps/leo_storage/src/leo_storage_mq.erl
+++ b/apps/leo_storage/src/leo_storage_mq.erl
@@ -461,8 +461,9 @@ handle_call({consume, ?QUEUE_ID_REQ_DEL_DIR, MessageBin}) ->
 handle_call({consume, MQId, MessageBin}) ->
     case lists:member(MQId, ?del_dir_id_list()) of
         true ->
-            %% Not handle the returun value of 'remove_objects_under_dir/1'
-            %% because 'replcation-failurre' which is fixed by 'leo_async_deletion_queue'
+            %% Need to handle the returun value of 'remove_objects_under_dir/1'
+            %% because there is a case that an item doesn't get inserted into 'leo_async_deletion_queue'
+            %% when leo_storage_handler_object:head in compare_between_metadatas failed.
             remove_objects_under_dir(MessageBin);
         false ->
             ok

--- a/apps/leo_storage/src/leo_storage_mq.erl
+++ b/apps/leo_storage/src/leo_storage_mq.erl
@@ -463,8 +463,7 @@ handle_call({consume, MQId, MessageBin}) ->
         true ->
             %% Not handle the returun value of 'remove_objects_under_dir/1'
             %% because 'replcation-failurre' which is fixed by 'leo_async_deletion_queue'
-            remove_objects_under_dir(MessageBin),
-            ok;
+            remove_objects_under_dir(MessageBin);
         false ->
             ok
     end;


### PR DESCRIPTION
A part of fix for **Not all objects from the bucket are deleted on storage node in the end (confirmed)** reported on https://github.com/leo-project/leofs/issues/725#issuecomment-320326336