### PR TITLE
storage: Fix for #803

### DIFF
--- a/apps/leo_storage/src/leo_storage_handler_del_directory.erl
+++ b/apps/leo_storage/src/leo_storage_handler_del_directory.erl
@@ -327,8 +327,15 @@ dequeue_1(State, [{_, DelBucketStateBin}|DelBucketStateList], MQId) ->
 insert_messages(From, MQId, Type, Directory, EnqueuedAt) ->
     erlang:send(From, {enqueuing, MQId, Type, Directory}),
 
+    DirTrailingSlash = case binary:last(Directory) of
+        $/ ->
+            Directory;
+        _ ->
+            << Directory/binary, "/" >>
+    end,
+
     case leo_storage_handler_object:prefix_search_and_remove_objects(
-           MQId, Directory, EnqueuedAt) of
+           MQId, DirTrailingSlash, EnqueuedAt) of
         {ok,_TotalMsgs} ->
             erlang:send(From, {enqueued, MQId, Type, Directory});
         {error, Cause} ->


### PR DESCRIPTION
Confirmed on my dev box with the procedure below.
- add-bucket body/bodytest
- put objects into those two
- delete-bucket body
- confirmed
  - objects that belong to body got deleted
  - objects that belong to bodytest get remained

also passed all integration test suites for delete-bucket.