### PR TITLE
manager: Fixes the multi datacenter replication feature for leo-project/leofs/issues/816

### DIFF
--- a/apps/leo_manager/include/leo_manager.hrl
+++ b/apps/leo_manager/include/leo_manager.hrl
@@ -320,6 +320,7 @@
 -define(ERROR_ALREADY_HAS_SAME_CLUSTER, "Already has a same neme of cluster").
 -define(ERROR_COULD_NOT_GET_CLUSTER_INFO,"Could not get cluster info").
 -define(ERROR_OVER_MAX_CLUSTERS, "Over max number of clusters").
+-define(ERROR_CLUSTER_NOT_FOUND, "Cluster not found").
 -define(ERROR_UPDATED_SYSTEM_CONF, "Updated the system configuration").
 -define(ERROR_FAILED_UPDATE_LOG_LEVEL, "Failed to update the log-level").
 -define(ERROR_FAILED_GET_VERSION, "Failed to get the version").


### PR DESCRIPTION
I've confirmed it has been fixed:

```bash
$ leofs-adm join-cluster manager_10@127.0.0.1:13095 manager_11@127.0.0.1:13096
OK

$ leofs-adm cluster-status
cluster id |   dc id    |    status    | # of storages  |          updated at
-----------+------------+--------------+----------------+-----------------------------
leofs_2    | dc_2       | running      |              4 | 2017-09-06 13:57:12 +0900

$ leofs-adm join-cluster manager_10@127.0.0.1:13095 manager_11@127.0.0.1:13096
[ERROR] Over max number of clusters

$ leofs-adm remove-cluster manager_10@127.0.0.1:13095 manager_11@127.0.0.1:13096
OK

$ leofs-adm cluster-status
[ERROR] Could not get cluster info

$ leofs-adm remove-cluster manager_10@127.0.0.1:13095 manager_11@127.0.0.1:13096
[ERROR] Cluster not found

$ leofs-adm join-cluster manager_10@127.0.0.1:13095 manager_11@127.0.0.1:13096
OK

$ leofs-adm cluster-status
cluster id |   dc id    |    status    | # of storages  |          updated at
-----------+------------+--------------+----------------+-----------------------------
leofs_2    | dc_2       | running      |              4 | 2017-09-06 13:57:39 +0900

$ leofs-adm join-cluster manager_10@127.0.0.1:13095 manager_11@127.0.0.1:13096
[ERROR] Over max number of clusters
```