### PR TITLE
storage: Change the interval checking the disk usage to 1 minute

### DIFF
--- a/apps/leo_storage/priv/leo_storage.schema
+++ b/apps/leo_storage/priv/leo_storage.schema
@@ -44,6 +44,15 @@
          {file, Path}
  end}.
 
+%% @doc The interval to check the disk usage in minutes
+{mapping,
+ "os_mon.disk_space_check_interval",
+ "os_mon.disk_space_check_interval",
+ [
+  {datatype, integer},
+  {default, 1}
+ ]}.
+
 %% @doc Restricts the error logging performed by the specified sasl_error_logger
 %%      to error reports, progress reports, or both.
 %%      errlog_type = [error | progress | all]


### PR DESCRIPTION
This is a part of the fix for https://github.com/leo-project/leofs/issues/592. https://github.com/leo-project/leo_object_storage/pull/11 completes the fix with this PR.

In my test env, The disk full almost never happen with this PR except a few extreme cases like
- The size of AVS is very small (several hundreds MB)
- The PUT throughput is massively high for around one minute

We might reconsider the problem to handle the above extreme cases in future.