### PR TITLE
manager: set timeout to prevent leofs-adm from hanging up

### DIFF
--- a/apps/leo_manager/include/leo_manager.hrl
+++ b/apps/leo_manager/include/leo_manager.hrl
@@ -46,6 +46,8 @@
 -define(DEF_RING_SYNC_INTERVAL, 10000). %%  10sec
 -endif.
 
+-define(TIMEOUT_FOR_LEOFSADM, 5000). %% 5sec
+
 -define(SYSTEM_CONF_FILE, "conf/leofs.conf").
 
 

--- a/apps/leo_manager/src/leo_manager_api.erl
+++ b/apps/leo_manager/src/leo_manager_api.erl
@@ -349,7 +349,7 @@ get_node_status(Node_1) ->
         undefined ->
             {error, not_found};
         _ ->
-            case rpc:call(Node_2, Mod, get_node_status, [], ?DEF_TIMEOUT) of
+            case rpc:call(Node_2, Mod, get_node_status, [], ?TIMEOUT_FOR_LEOFSADM) of
                 {ok, Status} ->
                     {ok, {Type, Status}};
                 {_, Cause} ->

--- a/apps/leo_manager/src/leo_manager_console.erl
+++ b/apps/leo_manager/src/leo_manager_console.erl
@@ -1081,7 +1081,7 @@ exchange_datatype(float, Val) ->
 update_property_2(Node, Method, Args) when is_atom(Node) ->
     case leo_misc:node_existence(Node) of
         true ->
-            case rpc:call(Node, leo_watchdog_api, Method, Args) of
+            case rpc:call(Node, leo_watchdog_api, Method, Args, ?TIMEOUT_FOR_LEOFSADM) of
                 {badrpc,_} ->
                     {error, ?ERROR_COULD_NOT_CONNECT};
                 Res ->
@@ -1140,7 +1140,7 @@ dump_ring(Option) ->
     case ?get_tokens(Option, ?ERROR_NOT_SPECIFIED_NODE) of
         {ok, [Node|_]} ->
             rpc:call(list_to_atom(Node),
-                     leo_redundant_manager_api, dump, [both]);
+                     leo_redundant_manager_api, dump, [both], ?TIMEOUT_FOR_LEOFSADM);
         Error ->
             Error
     end.
@@ -1286,7 +1286,7 @@ join_cluster_2([Node|Rest] = RemoteNodes) ->
                            [] ->
                                [RPCNode];
                            [Partner|_] ->
-                               case rpc:call(Partner, leo_rpc, node, []) of
+                               case rpc:call(Partner, leo_rpc, node, [], ?TIMEOUT_FOR_LEOFSADM) of
                                    {_,_Cause} ->
                                        [RPCNode];
                                    Partner_1 ->
@@ -1479,7 +1479,7 @@ version_all(Option) ->
                                         [] ->
                                             {"not_found", ?ERROR_FAILED_GET_VERSION};
                                         [Partner|_] ->
-                                            case rpc:call(Partner, application, get_env, [leo_manager, system_version]) of
+                                            case rpc:call(Partner, application, get_env, [leo_manager, system_version], ?TIMEOUT_FOR_LEOFSADM) of
                                                 {badrpc, _} ->
                                                     {atom_to_list(Partner), ?ERROR_FAILED_GET_VERSION};
                                                 {ok, SV} ->
@@ -1494,7 +1494,7 @@ version_all(Option) ->
                            {ok, R1} ->
                                lists:map(fun(N) ->
                                                  Node = N#node_state.node,
-                                                 V = case rpc:call(Node, leo_storage_api, get_info, [version]) of
+                                                 V = case rpc:call(Node, leo_storage_api, get_info, [version], ?TIMEOUT_FOR_LEOFSADM) of
                                                          {badrpc, _} ->
                                                              ?ERROR_FAILED_GET_VERSION;
                                                          Res ->
@@ -1511,7 +1511,7 @@ version_all(Option) ->
                            {ok, R2} ->
                                lists:map(fun(N) ->
                                                  Node = N#node_state.node,
-                                                 V = case rpc:call(Node, leo_gateway_api, get_info, [version]) of
+                                                 V = case rpc:call(Node, leo_gateway_api, get_info, [version], ?TIMEOUT_FOR_LEOFSADM) of
                                                          {badrpc, _} ->
                                                              ?ERROR_FAILED_GET_VERSION;
                                                          Res ->


### PR DESCRIPTION
Fix for https://github.com/leo-project/leofs/issues/817.
In addition to **status ${node}** and **version all** reported on the above issue, **update_property**, **join-cluster** and **dump-ring** could hang up so the explicit timeout has been set to rpc:call in those functions. 