### PR TITLE
Revert "storage: Pass Max Keys to backend db for prefix_search"

### DIFF
--- a/apps/leo_storage/src/leo_storage_handler_object.erl
+++ b/apps/leo_storage/src/leo_storage_handler_object.erl
@@ -929,7 +929,7 @@ prefix_search(ParentDir, Marker, MaxKeys) ->
           end,
 
     case catch leo_object_storage_api:fetch_by_key(
-                 ParentDir, Fun, MaxKeys) of
+                 ParentDir, Fun) of
         {'EXIT', Cause} when is_tuple(Cause) ->
             {error, element(1, Cause)};
         {'EXIT', Cause} ->

--- a/apps/leo_storage/test/leo_storage_handler_object_tests.erl
+++ b/apps/leo_storage/test/leo_storage_handler_object_tests.erl
@@ -477,7 +477,7 @@ copy_({Node0, Node1}) ->
 prefix_search_({_Node0, _Node1}) ->
     meck:new(leo_object_storage_api, [non_strict]),
     meck:expect(leo_object_storage_api, fetch_by_key,
-                fun(_ParentDir, Fun, _) ->
+                fun(_ParentDir, Fun) ->
                         Fun(?TEST_KEY_0, term_to_binary(#?METADATA{}), []),
                         Fun(?TEST_KEY_1, term_to_binary(#?METADATA{}), [#?METADATA{key=?TEST_KEY_0}])
                 end),


### PR DESCRIPTION
This reverts commit a9ba5a8eea4d16499d457f78909ce3faf6c7d6a4 to fix https://github.com/leo-project/leofs/issues/821.