### PR TITLE
Support running multiple instances of the same node

### DIFF
--- a/rel/common/launch.sh
+++ b/rel/common/launch.sh
@@ -240,7 +240,7 @@ case "$1" in
                 # Only look for processes launched with the same NODE_EXTRA_NAME env variable
                 # PID COMMAND+ENVIRONMENT
                 PID=`ps axeww o pid,args|\
-                    grep "NODE_EXTRA_NAME=$NODE_EXTRA_NAME" |\
+                    grep "NODE_EXTRA_NAME=$NODE_EXTRA_NAME " |\
                     grep "$RUNNER_BASE_DIR/.*/[b]eam"|awk '{print $1}'`
                 ;;
             Darwin|FreeBSD|DragonFly|NetBSD|OpenBSD)

--- a/rel/common/launch.sh
+++ b/rel/common/launch.sh
@@ -238,6 +238,7 @@ case "$1" in
         case `uname -s` in
             Linux)
                 # Only look for processes launched with the same NODE_EXTRA_NAME env variable
+                # This will fail (won't find anything) when stopping nodes launched by older version of script
                 # PID COMMAND+ENVIRONMENT
                 PID=`ps axeww o pid,args|\
                     grep "NODE_EXTRA_NAME=$NODE_EXTRA_NAME " |\

--- a/rel/service/leofs-gateway.service
+++ b/rel/service/leofs-gateway.service
@@ -7,9 +7,11 @@ Requires=leofs-epmd.socket
 After=leofs-manager-master.service leofs-manager-slave.service
 
 [Service]
+Environment=NODE_EXTRA_NAME=
 Type=simple
 User=leofs
 Group=leofs
+LimitNOFILE=65535
 
 ExecStart=/usr/local/leofs/current/leo_gateway/bin/leo_gateway foreground_start
 

--- a/rel/service/leofs-manager-master.service
+++ b/rel/service/leofs-manager-master.service
@@ -6,6 +6,7 @@ After=leofs-epmd.socket leofs-epmd.service
 Requires=leofs-epmd.socket
 
 [Service]
+Environment=NODE_EXTRA_NAME=
 Type=simple
 User=leofs
 Group=leofs

--- a/rel/service/leofs-manager-slave.service
+++ b/rel/service/leofs-manager-slave.service
@@ -7,6 +7,7 @@ Requires=leofs-epmd.socket
 After=leofs-manager-master.service
 
 [Service]
+Environment=NODE_EXTRA_NAME=
 Type=simple
 User=leofs
 Group=leofs

--- a/rel/service/leofs-storage.service
+++ b/rel/service/leofs-storage.service
@@ -7,9 +7,11 @@ Requires=leofs-epmd.socket
 After=leofs-manager-master.service leofs-manager-slave.service
 
 [Service]
+Environment=NODE_EXTRA_NAME=
 Type=simple
 User=leofs
 Group=leofs
+LimitNOFILE=65535
 
 ExecStart=/usr/local/leofs/current/leo_storage/bin/leo_storage foreground_start
 


### PR DESCRIPTION
Implementation of #792. Works only when using config from /etc/leofs.

Also increased "max open files" limit (systemd services only) for leo_gateway (for handling multiple connections) and for leo_storage (required when having > ~40 AVS files).