### PR TITLE
Ignoring a pre-generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ package/
 rel/leo_manager/files/leo_manager.conf
 rel/leo_manager/files/leo_manager.schema
 
+# ignore this because it is env dependent
+rel/common/launch.environment
+
 apps/leo_gateway/cache/
 
 docs/_book/


### PR DESCRIPTION
IMO the ```launch.environment```  should be ignored since it changes based on user build env (eg: username given while launching docker)