### PR TITLE
Fix recover-(file|node) issues and add the funcs for debug/test

### DIFF
--- a/apps/leo_manager/src/leo_manager_console.erl
+++ b/apps/leo_manager/src/leo_manager_console.erl
@@ -2060,7 +2060,8 @@ recover(Socket, Option) ->
             leo_manager_api:rebuild_dir_metadata(Socket, Prms);
         {ok, [Op, Key |Rest]} when Rest == [] ->
             HasRoutingTable = (leo_redundant_manager_api:checksum(ring) >= 0),
-            case catch leo_manager_api:recover(Op, Key, HasRoutingTable) of
+            Key2 = escape_large_obj_sep(Key),
+            case catch leo_manager_api:recover(Op, Key2, HasRoutingTable) of
                 ok ->
                     ok;
                 {_, Cause} ->

--- a/apps/leo_storage/src/leo_storage_api.erl
+++ b/apps/leo_storage/src/leo_storage_api.erl
@@ -260,7 +260,7 @@ synchronize(InconsistentNodes, #?METADATA{addr_id = AddrId,
     leo_storage_handler_object:replicate(InconsistentNodes, AddrId, Key);
 
 synchronize(Key, ErrorType) ->
-    {ok, #redundancies{vnode_id_to = VNodeId}} =
+    {ok, #redundancies{id = VNodeId}} =
         leo_redundant_manager_api:get_redundancies_by_key(Key),
     leo_storage_mq:publish(?QUEUE_ID_PER_OBJECT, VNodeId, Key, ErrorType).
 

--- a/apps/leo_storage/src/leo_storage_mq.erl
+++ b/apps/leo_storage/src/leo_storage_mq.erl
@@ -608,8 +608,8 @@ send_object_to_remote_node(Node, AddrId, Key) ->
                 {'EXIT', Cause} ->
                     %% unexpected case now @vstax seems to face
                     %% invalid binary may be stored on leveldb if so have to vet the raw binary
-                    %% that can be retrieved from debug outputs below.
-                    ?debug("send_object_to_remote_node/3 - binary_to_term",
+                    %% that can be retrieved from error outputs below.
+                    ?error("send_object_to_remote_node/3 - binary_to_term",
                           [{node, Node},
                            {addr_id, AddrId},
                            {key, Key},
@@ -619,8 +619,8 @@ send_object_to_remote_node(Node, AddrId, Key) ->
         {'EXIT', Cause} ->
             %% unexpected case now @vstax seems to face
             %% invalid binary may be stored on leveldb so we have to vet the raw binary
-            %% that can be retrieved from debug outputs below.
-            ?debug("send_object_to_remote_node/3 - leo_object_storage_api:head",
+            %% that can be retrieved from error outputs below.
+            ?error("send_object_to_remote_node/3 - leo_object_storage_api:head",
                    [{node, Node},
                     {addr_id, AddrId},
                     {key, Key},

--- a/apps/leo_storage/src/leo_storage_mq.erl
+++ b/apps/leo_storage/src/leo_storage_mq.erl
@@ -568,27 +568,13 @@ recover_node_callback_2([SrcNode|Rest], AddrId, Key, FixedNode) ->
                                       Key::binary(),
                                       Cause::any()).
 send_object_to_remote_node(Node, AddrId, Key) ->
-    Ref = make_ref(),
-    case leo_storage_handler_object:get({Ref, Key}) of
-        {ok, Ref, Metadata, Bin} ->
-            case rpc:call(Node, leo_sync_local_cluster, store,
-                          [Metadata, Bin], ?DEF_REQ_TIMEOUT) of
-                ok ->
-                    ok;
-                {error, inconsistent_obj} ->
-                    ?MODULE:publish(?QUEUE_ID_PER_OBJECT,
-                                    AddrId, Key, ?ERR_TYPE_RECOVER_DATA);
-                _ ->
-                    ?MODULE:publish(?QUEUE_ID_PER_OBJECT, AddrId, Key,
-                                    Node, true, ?ERR_TYPE_RECOVER_DATA)
-            end;
-        {error, Ref, not_found} ->
-            %% for objects deleted
-            case leo_object_storage_api:head({AddrId, Key}) of
-                {ok, MetaBin} ->
-                    Metadata = binary_to_term(MetaBin),
+    case catch leo_object_storage_api:head({AddrId, Key}) of
+        {ok, MetaBin} ->
+            case catch binary_to_term(MetaBin) of
+                #?METADATA{del = ?DEL_TRUE} = Meta ->
+                    %% for objects deleted
                     case rpc:call(Node, leo_sync_local_cluster, store,
-                          [Metadata, <<>>], ?DEF_REQ_TIMEOUT) of
+                          [Meta, <<>>], ?DEF_REQ_TIMEOUT) of
                         ok ->
                             ok;
                         {error, inconsistent_obj} ->
@@ -598,14 +584,53 @@ send_object_to_remote_node(Node, AddrId, Key) ->
                             ?MODULE:publish(?QUEUE_ID_PER_OBJECT, AddrId, Key,
                                             Node, true, ?ERR_TYPE_RECOVER_DATA)
                     end;
-                _ ->
-                    ?MODULE:publish(?QUEUE_ID_PER_OBJECT, AddrId, Key,
-                                    Node, true, ?ERR_TYPE_RECOVER_DATA)
+                #?METADATA{del = ?DEL_FALSE} = Meta ->
+                    %% for objects existing
+                    Ref = make_ref(),
+                    case leo_storage_handler_object:get({Ref, Key}) of
+                        {ok, Ref, Meta, Bin} ->
+                            case rpc:call(Node, leo_sync_local_cluster, store,
+                                          [Meta, Bin], ?DEF_REQ_TIMEOUT) of
+                                ok ->
+                                    ok;
+                                {error, inconsistent_obj} ->
+                                    ?MODULE:publish(?QUEUE_ID_PER_OBJECT,
+                                                    AddrId, Key, ?ERR_TYPE_RECOVER_DATA);
+                                _ ->
+                                    ?MODULE:publish(?QUEUE_ID_PER_OBJECT, AddrId, Key,
+                                                    Node, true, ?ERR_TYPE_RECOVER_DATA)
+                            end;
+                        {error, Ref, Cause} ->
+                            {error, Cause};
+                        _Other ->
+                            {error, invalid_response}
+                    end;
+                {'EXIT', Cause} ->
+                    %% unexpected case now @vstax seems to face
+                    %% invalid binary may be stored on leveldb if so have to vet the raw binary
+                    %% that can be retrieved from debug outputs below.
+                    ?debug("send_object_to_remote_node/3 - binary_to_term",
+                          [{node, Node},
+                           {addr_id, AddrId},
+                           {key, Key},
+                           {cause, Cause}]),
+                    {error, Cause}
             end;
-        {error, Ref, Cause} ->
+        {'EXIT', Cause} ->
+            %% unexpected case now @vstax seems to face
+            %% invalid binary may be stored on leveldb so we have to vet the raw binary
+            %% that can be retrieved from debug outputs below.
+            ?debug("send_object_to_remote_node/3 - leo_object_storage_api:head",
+                   [{node, Node},
+                    {addr_id, AddrId},
+                    {key, Key},
+                    {cause, Cause}]),
             {error, Cause};
-        _Other ->
-            {error, invalid_response}
+        not_found ->
+            %% no data to send remote nodes
+            ok;
+        {error, Cause} ->
+            {error, Cause}
     end.
 
 


### PR DESCRIPTION
Note: funcs added for debug/test can be used on remote_console and also will be used at leofs_test2 to increase the test coverage like
- https://github.com/leo-project/leofs/issues/875