### PR TITLE
Config to allow increase of open files limit on Linux

### DIFF
--- a/rel/common/leofs-limits.conf
+++ b/rel/common/leofs-limits.conf
@@ -1,0 +1,4 @@
+# Increase amount of open files (required by LeoGateway and LeoStorage on some systems)
+
+leofs       soft    nofile     65535
+leofs       hard    nofile     65535


### PR DESCRIPTION
When installed by rpm/deb package, raises default limit of 1024 open files, which isn't enough when having many AVS files on storage or high load on gateway. It is already raised for systemd services, this is only required when launching directly through script.