### PR TITLE
Increase open files limit

### DIFF
--- a/rel/common/launch.environment
+++ b/rel/common/launch.environment
@@ -12,3 +12,6 @@
 
 # Defaults to "leofs"
 RUNNER_USER=
+
+# Defaults to 65535
+# MAX_OPEN_FILES=

--- a/rel/common/launch.sh
+++ b/rel/common/launch.sh
@@ -61,6 +61,11 @@ cd $RUNNER_BASE_DIR
 # Make sure log directory exists
 mkdir -p $RUNNER_LOG_DIR
 
+# Try to increase open files limit. Workaround for Ubuntu (and maybe others) default
+# sudo settings which don't use PAM to set limits automatically. Error is silenced because
+# there are known cases when limit can't be changed (e.g. launching managers under systemd)
+ulimit -n ${MAX_OPEN_FILES:-65535} 2> /dev/null
+
 help () {
     echo "Usage: $SCRIPT [-type leo_manager|leo_gateway|leo_storage] {start|stop|restart|foreground_start|reboot|ping|console|console_clean|attach|remote_console}"
     echo "Script type is picked from its name, but can be overriden with -type option"

--- a/rel/common/leofs-limits.conf
+++ b/rel/common/leofs-limits.conf
@@ -1,0 +1,4 @@
+# Increase amount of open files (required by LeoGateway and LeoStorage on some systems)
+
+leofs       soft    nofile     65535
+leofs       hard    nofile     65535


### PR DESCRIPTION
When installed by rpm/deb package (https://github.com/leo-project/leofs_package/pull/10), limits config raises default limit of 1024 open files, which isn't enough when having many AVS files on storage or high load on gateway. It is already raised for systemd services, this is only required when launching directly through script.
Also contains workaround for Ubuntu sudo settings (#883).