### PR TITLE
Change documentation to prepare for 1.3.8 release

### DIFF
--- a/docs/admin/settings/environment_config.md
+++ b/docs/admin/settings/environment_config.md
@@ -32,7 +32,7 @@ $ /usr/local/leofs/<new_version>/leo_manager_0/bin/leo_manager start
 With this, users can place actual config files (like `leo_manager.conf`) to the directory of their choice and change them independently of version upgrades, and the `.environment` files that need to be placed into installation tree don't need to be changed between versions. With the correct setup, since no work/temporary files will be kept in the installation tree, old version can be removed cleanly.
 
 !!! note "Note: When managing nodes through systemd"
-    Please do not use example commands above (`leo_manager stop/start`) when running nodes as systemd services for LeoFS v1.4.0 or later, use `systemctl stop/start leofs-manager-master` instead.
+    Please do not use example commands above (`leo_manager stop/start`) when running nodes as systemd services for LeoFS v1.3.8 or later, use `systemctl stop/start leofs-manager-master` instead.
 
 
 ## Example Configuration

--- a/docs/admin/system_admin/migration.md
+++ b/docs/admin/system_admin/migration.md
@@ -62,17 +62,17 @@ obj_containers.sync_interval_in_ms = 1000
 ```
 
 
-### Changes in LeoFS' Packages (1.4.0+)
+### Changes in LeoFS' Packages (1.3.8+)
 
-Starting from v1.4.0 there are changes in [the official Linux packages](http://leo-project.net/leofs/download.html). They should work out of the box for new installations and for new nodes on existing installations. However, one needs to pay special attention during upgrading existing nodes to v1.4.0.
+Starting from v1.3.8 there are changes in [the official Linux packages](http://leo-project.net/leofs/download.html). They should work out of the box for new installations and for new nodes on existing installations. However, one needs to pay special attention during upgrading existing nodes to v1.3.8.
 
 - for all supported distributions: there is now symlink `/usr/local/leofs/current` which points to `/usr/local/leofs/<version>`, this allows fixed path to launch scripts, independent of LeoFS version (e.g. `/usr/local/leofs/current/leo_manager_0/bin/leo_manager`). Users that created symlink with that name themselves should remove it before installing new package.
 - for EL6 / EL7 packages: installing multiple versions of LeoFS package is not supported anymore. There can be only one version of `leofs` package installed in system; new version should only be installed as upgrade, with `rpm -U` / `rpm -F`.
 - for systemd-based distributions (Ubuntu 16.04, EL7) special upgrade steps are needed.
 
-#### Procedure of installing v1.4.0 upgrade for systemd-based distributions (Ubuntu 16.04 and EL7)
+#### Procedure of installing v1.3.8 upgrade for systemd-based distributions (Ubuntu 16.04 and EL7)
 
-When upgrading existing node running LeoFS package 1.3.7 or earlier to v1.4.0 or later, please follow these steps:
+When upgrading existing node running LeoFS package 1.3.7 or earlier to v1.3.8 or later, please follow these steps:
 
 - Stop currently running LeoFS node. Backup current config files for that node, if needed.
 - Execute `pgrep -a epmd` and make sure there is **no output**, i.e. no instances of epmd are running. If there are any, kill them with `pkill epmd` command. Never kill `epmd` while LeoFS node is still running, though, because it will render it non-functional until restart.
@@ -91,7 +91,7 @@ In that case, users must do the following before trying to start the new version
 
 (or, alternatively, system reboot will take care of this problem as well).
 
-These special steps are not needed for installing upgrades after v1.4.0.
+These special steps are not needed for installing upgrades after v1.3.8.
 
 After upgrade, users of systemd-based distributions might be interested in switching to new way of launching nodes which offers improvements for system administration and new features like automatic startup/shutdown of LeoFS node on startup or reboot. Please read [For Administrators / System Operations / Systemd Services](/admin/system_operations/systemd.md) for more information.
 

--- a/docs/admin/system_admin/multiple_nodes.md
+++ b/docs/admin/system_admin/multiple_nodes.md
@@ -2,7 +2,7 @@
 
 ## Description and requirements
 
-Starting from v1.4.0, there is support for running multiple instances of the same node types on a single system (without use of containers or other type of isolation). This is useful for users who want to do things like
+Starting from v1.3.8, there is support for running multiple instances of the same node types on a single system (without use of containers or other type of isolation). This is useful for users who want to do things like
 
 - Running two (or more) gateways on the same system (in the same or different mode, e.g. S3 gateway + REST gateway)
 - Running two (or more) completely isolated clusters with different settings on the same set of storage servers
@@ -148,7 +148,7 @@ erlang.crash_dump = /var/log/leofs/leo_storage_second/erl_crash.dump
 snmp_conf = ./snmp/snmpa_storage_1/leo_storage_snmp
 ```
 
-Each node requires own set of directories with appropriate permissiosn:
+Each node requires own set of directories with appropriate permissions:
 ```
 # mkdir -p /var/leofs/leo_storage/work/queue /var/log/leofs/leo_storage/app /var/leofs/leo_storage/work/ord_reda /var/log/leofs/leo_storage/sasl
 # chown -R leofs:leofs /var/leofs/leo_storage/ /var/log/leofs/

--- a/docs/admin/system_admin/persistent_configuration.md
+++ b/docs/admin/system_admin/persistent_configuration.md
@@ -2,7 +2,7 @@
 
 ## Node configuration in `/etc/leofs`
 
-Starting from v1.4.0, LeoFS nodes support loading configuration from `/etc/leofs` hierarchy. This means that there are two locations from which nodes can load their configuration (but only one can be enabled at any time). Official Linux packages ship a copy of config files in `/etc/leofs/leo_*`, though the feature itself should work on any system. However, it is **disabled** by default for compatibility with older versions. 
+Starting from v1.3.8, LeoFS nodes support loading configuration from `/etc/leofs` hierarchy. This means that there are two locations from which nodes can load their configuration (but only one can be enabled at any time). Official Linux packages ship a copy of config files in `/etc/leofs/leo_*`, though the feature itself should work on any system. However, it is **disabled** by default for compatibility with older versions.
 
 ### Different configuration directory for each LeoFS version
 
@@ -24,7 +24,7 @@ For each LeoFS version, these directories will be different (e.g. `/usr/local/le
 
 ### Same configuration directory for all versions
 
-For LeoFS v1.4.0 or later, when `/etc/leofs/leofs.conf` exists and contains `GLOBAL_CONFIG=yes`, configuration is loaded from these directories - independent from version or binaries location:
+For LeoFS v1.3.8 or later, when `/etc/leofs/leofs.conf` exists and contains `GLOBAL_CONFIG=yes`, configuration is loaded from these directories - independent from version or binaries location:
 
 | Node Type       | Full Path  |
 | --------------- | ---------- |

--- a/docs/admin/system_operations/systemd.md
+++ b/docs/admin/system_operations/systemd.md
@@ -4,13 +4,13 @@ This section describes how to manage LeoFS nodes on systemd-based Linux distribu
 
 ## Requirements
 
-Users of LeoFS v1.4.0 or higher running official Linux packages under supported systemd-based Linux distros (currently: Ubuntu 16.04 and EL7-based) can use supplied systemd units for starting/stopping nodes. Advantages offered by doing so include:
+Users of LeoFS v1.3.8 or higher running official Linux packages under supported systemd-based Linux distros (currently: Ubuntu 16.04 and EL7-based) can use supplied systemd units for starting/stopping nodes. Advantages offered by doing so include:
 
 - Way to automatically start nodes on system startup and correctly shutdown them during power off / reboot.
 - Reliable way of controlling nodes (e.g. when LeoStorage node is launched in absence of LeoManager nodes, it will keep on restarting till LeoManager becomes available; nodes always being able to restart in case of unexpected situation such as crash or OOM kill)
 - Correct inter-node dependencies (affecting startup/shutdown order) for launching nodes in all-in-one cluster (when all nodes are running on the same system, e.g. for testing)
 
-It's possible to switch to systemd-based way to control nodes (and back) anytime for users of v1.4.0 and higher running any supported systemd-based Linux distro.
+It's possible to switch to systemd-based way to control nodes (and back) anytime for users of v1.3.8 and higher running any supported systemd-based Linux distro.
 
 
 ## Switching to systemd services
@@ -73,6 +73,6 @@ In some cases (primary, LeoStorage under high write load) a node can take a long
 
 This section only applies to people who need to run LeoFS node **and** some other Erlang software on the same system.
 
-LeoFS, as well as certain types of other Erlang software relies on Erlang Port Mapper Daemon (`epmd`). Usually there can be only single instance of `epmd` running on the same node. To ensure smooth LeoFS operation, v1.4.0 and higher packages ensure that `leofs-epmd.socket` is enabled on boot and started right after upgrade. This is the case even when not using systemd-based services to launch LeoFS nodes. This service is running as "leofs" user by default (there should be no need to change that).
+LeoFS, as well as certain types of other Erlang software relies on Erlang Port Mapper Daemon (`epmd`). Usually there can be only single instance of `epmd` running on the same node. To ensure smooth LeoFS operation, v1.3.8 and higher packages ensure that `leofs-epmd.socket` is enabled on boot and started right after upgrade. This is the case even when not using systemd-based services to launch LeoFS nodes. This service is running as "leofs" user by default (there should be no need to change that).
 
 Usually, service for LeoFS-supplied `epmd` (which uses socket activation) should work even for other Erlang software that might need `epmd` and there will be no problems. However, in case running some other instance of `epmd` is really needed, it should be possible to mask `leofs-epmd.socket` and `leofs-epmd.service` and remove dependencies on these units. It should work as long as `epmd` is always running before launching LeoFS nodes and is set up to listen on all interfaces (`0.0.0.0`), not just the local one.


### PR DESCRIPTION
Can be previewed at https://vstax.github.io/leofs/ but it's really just a 1.4.0 -> 1.3.8 change where relevant