### PR TITLE
Make ERL_CRASH_DUMP_SECONDS configurable without changing main script

### DIFF
--- a/rel/common/launch.environment
+++ b/rel/common/launch.environment
@@ -15,3 +15,11 @@ RUNNER_USER=
 
 # Defaults to 65535
 # MAX_OPEN_FILES=
+
+# Defaults to "0" when launched under systemd or heart is active, which means
+# that no dumps are created before restart. Uncomment line below to set it to
+# "-1" and create dumps on every crash if leo_(manager|storage|gateway) is
+# restarted frequently in order to dig down further for identifying the root
+# cause. "-1" means that runtime system won't be rebooted until the crash dump
+# file is completely written.
+# ERL_CRASH_DUMP_SECONDS=-1

--- a/rel/common/launch.sh
+++ b/rel/common/launch.sh
@@ -227,12 +227,9 @@ case "$1" in
         HEART_COMMAND="$RUNNER_BASE_DIR/bin/$SCRIPT start"
         export HEART_COMMAND
 
-        # Uncomment the below two lines ONLY if you face leo_(manager|storage|gateway) restarted frequently
-        # in order to dig down further for identifying the root cause.
-        # ERL_CRASH_DUMP_SECONDS=-1 means setting the environment variable to a negative value
-        # does not reboot the runtime system until the crash dump file is completely written.
-        ## ERL_CRASH_DUMP_SECONDS=-1
-        ## export ERL_CRASH_DUMP_SECONDS
+        ERL_CRASH_DUMP_SECONDS=${ERL_CRASH_DUMP_SECONDS:-0}
+        export ERL_CRASH_DUMP_SECONDS
+
         mkdir -p $PIPE_DIR
         shift # remove $1
         $ERTS_PATH/run_erl -daemon $PIPE_DIR $RUNNER_LOG_DIR "exec $RUNNER_BASE_DIR/bin/$SCRIPT console $@" 2>&1
@@ -379,11 +376,7 @@ case "$1" in
                 exit 1
             fi
 
-            # Default value ERL_CRASH_DUMP_SECONDS=-1 will create dumps on every crash, which isn't desirable
-            # when external hearbeat (e.g. in systemd service) is used. 
-            # Comment the below two lines ONLY if you face leo_(manager|storage|gateway) restarted frequently
-            # in order to dig down further for identifying the root cause.
-            ERL_CRASH_DUMP_SECONDS=0
+            ERL_CRASH_DUMP_SECONDS=${ERL_CRASH_DUMP_SECONDS:-0}
             export ERL_CRASH_DUMP_SECONDS
         fi
 


### PR DESCRIPTION
It can be set in environment file or systemd unit file and script will pick the setting.