### PR TITLE
Fixed for leo-project/leofs#835

### DIFF
--- a/apps/leo_gateway/src/leo_gateway_http_commons.erl
+++ b/apps/leo_gateway/src/leo_gateway_http_commons.erl
@@ -241,12 +241,11 @@ onresponse(#cache_condition{expire = Expire} = Config, FunGenKey) ->
                                                            end
                                                    end, [], Header1),
                             CMetaBin = case MetaList of
-                                       [] ->
-                                           <<>>;
-                                       _ ->
-                                           term_to_binary(MetaList)
-                                   end,
-
+                                           [] ->
+                                               <<>>;
+                                           _ ->
+                                               term_to_binary(MetaList)
+                                       end,
                             Bin = term_to_binary(
                                     #cache{mtime = Now,
                                            etag = leo_hex:raw_binary_to_integer(crypto:hash(md5, Body)),
@@ -254,7 +253,6 @@ onresponse(#cache_condition{expire = Expire} = Config, FunGenKey) ->
                                            body = Body,
                                            cmeta = CMetaBin,
                                            msize = byte_size(CMetaBin),
-
                                            content_type = ?http_content_type(Header1)}),
                             catch leo_cache_api:put(Key, Bin),
                             Header2 = lists:keydelete(?HTTP_HEAD_LAST_MODIFIED, 1, Header1),
@@ -433,7 +431,7 @@ get_object_with_cache(Req, Key, CacheObj, #req_params{bucket_name = BucketName,
                        {?HTTP_HEAD_RESP_LAST_MODIFIED, leo_http:rfc1123_date(CacheObj#cache.mtime)},
                        {?HTTP_HEAD_X_FROM_CACHE, <<"True/via disk">>}],
             {ok, CustomHeaders} = leo_nginx_conf_parser:get_custom_headers(Key, CustomHeaderSettings),
-            
+
             case leo_gateway_rpc_handler:head(Key) of
                 {ok, #?METADATA{meta = CMetaBin}} ->
                     Headers2 = case CMetaBin of
@@ -767,11 +765,14 @@ put_small_object({ok, {Size, Bin, Req}}, Key, #req_params{bucket_name = BucketNa
                   andalso binary_is_contained(Key, 10) == false) of
                 true  ->
                     Mime = leo_mime:guess_mime(Key),
+                    CMeta_1 = term_to_binary(
+                                leo_misc:get_value(
+                                  ?PROP_CMETA_UDM, binary_to_term(CMeta), [])),
                     Val = term_to_binary(#cache{etag = ETag,
                                                 mtime = leo_date:now(),
                                                 content_type = Mime,
                                                 body = Bin,
-                                                cmeta = CMeta,
+                                                cmeta = CMeta_1,
                                                 msize = byte_size(CMeta),
                                                 size = byte_size(Bin)
                                                }),

--- a/apps/leo_gateway/src/leo_gateway_s3_api.erl
+++ b/apps/leo_gateway/src/leo_gateway_s3_api.erl
@@ -472,17 +472,17 @@ get_object(Req, Key, #req_params{is_acl = true,
                     XML = generate_acl_xml(BucketInfo),
                     Header = [?SERVER_HEADER,
                               {?HTTP_HEAD_RESP_CONTENT_TYPE, ?HTTP_CTYPE_XML}],
-                    ?access_log_get_acl(Bucket, Key, ?HTTP_ST_OK, BeginTime), 
+                    ?access_log_get_acl(Bucket, Key, ?HTTP_ST_OK, BeginTime),
                     ?reply_ok(Header, XML, Req);
                 not_found ->
-                    ?access_log_get_acl(Bucket, Key, ?HTTP_ST_NOT_FOUND, BeginTime), 
+                    ?access_log_get_acl(Bucket, Key, ?HTTP_ST_NOT_FOUND, BeginTime),
                     ?reply_not_found([?SERVER_HEADER], Bucket, <<>>, Req);
                 {error, _Cause} ->
                     ?access_log_get_acl(Bucket, Key, ?HTTP_ST_INTERNAL_ERROR, BeginTime),
                     ?reply_internal_error([?SERVER_HEADER], Bucket, <<>>, Req)
             end;
         {ok, #?METADATA{del = 1}}->
-            ?access_log_get_acl(Bucket, Key, ?HTTP_ST_NOT_FOUND, BeginTime), 
+            ?access_log_get_acl(Bucket, Key, ?HTTP_ST_NOT_FOUND, BeginTime),
             ?reply_not_found([?SERVER_HEADER], Key, <<>>, Req);
         {error, Cause} ->
             ?reply_fun(Cause, get_acl, Bucket, Key, 0, Req, BeginTime)
@@ -2236,9 +2236,9 @@ parse_headers_to_cmeta(Headers) when is_list(Headers) ->
                            end, [], Headers),
     case MetaList of
         [] ->
-            {ok, <<>>};
+            {ok, term_to_binary([])};
         _ ->
-            {ok, term_to_binary(MetaList)}
+            {ok, term_to_binary([{?PROP_CMETA_UDM, MetaList}])}
     end;
 parse_headers_to_cmeta(_) ->
     {error, badarg}.

--- a/apps/leo_storage/src/leo_storage_handler_object.erl
+++ b/apps/leo_storage/src/leo_storage_handler_object.erl
@@ -110,6 +110,7 @@ get(ReadParameter, Redundancies) when Redundancies /= [] ->
     case read_and_repair(ReadParameter, Redundancies) of
         {ok, #?METADATA{meta = CMeta} = Meta, Bin} when CMeta =/= <<>> ->
             {ok, NewMeta} = get_cmeta(Meta),
+
             {ok, NewMeta, Bin};
         Other ->
             Other
@@ -1251,6 +1252,7 @@ read_and_repair_2(#read_parameter{addr_id = AddrId,
     %%     then compare it with requested 'Etag'
     HeadRet = case leo_object_storage_api:head({AddrId, Key}) of
                   {ok, MetaBin} ->
+
                       Metadata = binary_to_term(MetaBin),
                       case Metadata#?METADATA.checksum of
                           ETag ->

--- a/apps/leo_storage/src/leo_storage_mq.erl
+++ b/apps/leo_storage/src/leo_storage_mq.erl
@@ -1030,7 +1030,7 @@ fix_consistency_between_clusters(#inconsistent_data_with_dc{
                           addr_id = AddrId,
                           key = Key,
                           dsize = 0,
-                          del = ?DEL_FALSE},
+                          del = ?DEL_TRUE},
     Object = leo_object_storage_transformer:metadata_to_object(Metadata),
     leo_sync_remote_cluster:stack(Object#?OBJECT{data = <<>>}).
 

--- a/apps/leo_storage/src/leo_sync_remote_cluster.erl
+++ b/apps/leo_storage/src/leo_sync_remote_cluster.erl
@@ -344,10 +344,16 @@ stack_fun(ClusterId, #?OBJECT{addr_id = AddrId,
                  mdcr_r = MDCR_R,
                  mdcr_w = MDCR_W,
                  mdcr_d = MDCR_D}} ->
+            UDM_1 = case leo_object_storage_transformer:get_udm_from_cmeta_bin(CMeta) of
+                        {ok, UDM} when UDM /= [] ->
+                            UDM;
+                        _ ->
+                            []
+                    end,
             CMeta_1 = leo_object_storage_transformer:list_to_cmeta_bin(
                          [{?PROP_CMETA_CLUSTER_ID, MDC_ClusterId},
                           {?PROP_CMETA_NUM_OF_REPLICAS, MDCR_N},
-                          {?PROP_CMETA_UDM, leo_object_storage_transformer:get_udm_from_cmeta_bin(CMeta)}
+                          {?PROP_CMETA_UDM, UDM_1}
                          ]),
             CMetaLen = byte_size(CMeta_1),
             Object_1 =  Object#?OBJECT{cluster_id = MDC_ClusterId,
@@ -425,7 +431,6 @@ slice(StackedObjs) ->
     end.
 
 
-%% @TODO
 %% @doc Replicate an object between clusters
 %% @private
 -spec(replicate(atom(), #object{} | #object_1{} | #?OBJECT{}) ->


### PR DESCRIPTION
I've fixed #835 issue, there are root causes at LeoGateway and LeoStorage, then tested its issue as below:

#### Preparation

```bash
$ leofs-adm join-cluster manager_10@127.0.0.1:13095 manager_11@127.0.0.1:13096
OK
$ ./leofs-adm -p 10110 update-acl test 05236 public-read
OK
$ ./leofs-adm update-acl test 05236 public-read
OK
```
 
#### Put an object into Cluster-1:

```bash
$ s3cmd put --add-header=x-amz-meta-testkey:testvalue ./rebar.config s3://test/
./rebar.config -> s3://test/rebar.config  [1 of 1]
 1090 of 1090   100% in    0s    54.38 kB/s  done
```

#### Cluster-1:

```bash
 curl -v http://localhost:8080/test/rebar.config > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1...
* connect to ::1 port 8080 failed: Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /test/rebar.config HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.47.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Connection: keep-alive
< Date: Tue, 31 Oct 2017 02:22:53 GMT
< Content-Length: 1090
< x-amz-meta-testkey: testvalue
< x-amz-meta-s3cmd-attrs: uid:1000/gname:yosuke/uname:yosuke/gid:1000/mode:33204/mtime:1509415986/atime:1509415989/md5:406dc41482a63e42bc546401b753759f/ctime:1509415986
< Server: LeoFS
< Content-Type: application/octet-stream
< ETag: "406dc41482a63e42bc546401b753759f"
< Last-Modified: Tue, 31 Oct 2017 02:22:23 GMT
< X-From-Cache: True/via memory
<
{ [1090 bytes data]
100  1090  100  1090    0     0   138k      0 --:--:-- --:--:-- --:--:--  152k
* Connection #0 to host localhost left intact
```

#### Cluster-2:

```bash
$ curl -v http://localhost:18080/test/rebar.config > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1...
* connect to ::1 port 18080 failed: Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 18080 (#0)
> GET /test/rebar.config HTTP/1.1
> Host: localhost:18080
> User-Agent: curl/7.47.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Connection: keep-alive
< Date: Tue, 31 Oct 2017 02:23:00 GMT
< Content-Length: 1090
< x-amz-meta-testkey: testvalue
< x-amz-meta-s3cmd-attrs: uid:1000/gname:yosuke/uname:yosuke/gid:1000/mode:33204/mtime:1509415986/atime:1509415989/md5:406dc41482a63e42bc546401b753759f/ctime:1509415986
< Server: LeoFS
< Content-Type: application/octet-stream
< ETag: "406dc41482a63e42bc546401b753759f"
< Last-Modified: Tue, 31 Oct 2017 02:22:23 GMT
<
{ [1090 bytes data]
100  1090  100  1090    0     0  97278      0 --:--:-- --:--:-- --:--:-- 99090
* Connection #0 to host localhost left intact
```