### PR TITLE
storage: Fix for #912

### DIFF
--- a/apps/leo_storage/include/leo_storage.hrl
+++ b/apps/leo_storage/include/leo_storage.hrl
@@ -531,6 +531,13 @@
                     _Time
             end
         end).
+-define(env_storage_watchdog_msgs_enabled(),
+        case application:get_env(leo_storage, watchdog_msgs_enabled) of
+            {ok, EnvWathdogMsgEnabled} ->
+                EnvWathdogMsgEnabled;
+            _ ->
+                false
+        end).
 
 %% @doc Storage autonomic-operation related
 -define(env_auto_compaction_enabled(),

--- a/apps/leo_storage/priv/leo_storage.conf
+++ b/apps/leo_storage/priv/leo_storage.conf
@@ -177,6 +177,14 @@ watchdog.error.interval = 60
 ## error - threshold error count - default:100
 watchdog.error.threshold_count = 100
 
+##
+##  Watchdog.Messages
+##
+## Traking the number of slow operations and timeouts happened on leo_object_storage
+## and get triggered when the number goes above a certain threshold
+##
+## Is messages-watchdog enabled - default:false
+watchdog.msgs.is_enabled = false
 
 ## --------------------------------------------------------------------
 ## STORAGE - Autonomic Operation

--- a/apps/leo_storage/priv/leo_storage.schema
+++ b/apps/leo_storage/priv/leo_storage.schema
@@ -649,6 +649,17 @@
   {default, 100}
  ]}.
 
+%%
+%%  Watchdog.Messages
+%%
+%% @doc Messages - Is enabled
+{mapping,
+ "watchdog.msgs.is_enabled",
+ "leo_storage.watchdog_msgs_enabled",
+ [
+  {datatype, {enum, [true, false]}},
+  {default, false}
+ ]}.
 
 %% --------------------------------------------------------------------
 %% STORAGE - Autonomic operation

--- a/apps/leo_storage/src/leo_storage_watchdog_msgs.erl
+++ b/apps/leo_storage/src/leo_storage_watchdog_msgs.erl
@@ -136,16 +136,24 @@ handle_notified_messages(Id, NumOfNotifiedMsgs) ->
                     + erlang:length(leo_misc:get_value(?MSG_ITEM_SLOW_OP, Msgs, [])),
                 case (Len >= NumOfNotifiedMsgs) of
                     true ->
+						error_logger:warning_msg("~p,~p,~p,~p~n",
+                                                 [{module, ?MODULE_STRING},
+                                                  {function, "handle_notified_messages/2"},{line, ?LINE},
+                                                  {body, [{triggered_watchdog, num_of_notified_msgs, Len}]}]),
                         %% raise error
-                        elarm:raise(Id, ?WD_ITEM_ACTIVE_SIZE_RATIO,
+                        elarm:raise(Id, ?WD_ITEM_NOTIFIED_MSGS,
                                     #watchdog_state{id = Id,
                                                     level = ?WD_LEVEL_ERROR,
                                                     src   = ?WD_ITEM_NOTIFIED_MSGS,
                                                     props = [{num_of_notified_msgs, Len}
                                                             ]});
                     false when Len >= WarnNumOfNotifiedMsgs ->
+						error_logger:warning_msg("~p,~p,~p,~p~n",
+                                                 [{module, ?MODULE_STRING},
+                                                  {function, "handle_notified_messages/2"},{line, ?LINE},
+                                                  {body, [{triggered_watchdog, num_of_notified_msgs, Len}]}]),
                         %% raise warning
-                        elarm:raise(Id, ?WD_ITEM_ACTIVE_SIZE_RATIO,
+                        elarm:raise(Id, ?WD_ITEM_NOTIFIED_MSGS,
                                     #watchdog_state{id = Id,
                                                     level = ?WD_LEVEL_WARN,
                                                     src   = ?WD_ITEM_NOTIFIED_MSGS,


### PR DESCRIPTION
Fixed #912 and also fixed existing bugs (stored a slow operation message as a timeout one, raised items were not cleared)