### PR TITLE
gateway: Fix for #894

### DIFF
--- a/apps/leo_gateway/src/leo_large_object_get_handler.erl
+++ b/apps/leo_gateway/src/leo_large_object_get_handler.erl
@@ -244,7 +244,7 @@ handle_loop(Index, TotalChunkObjs, #req_info{key = AcctualKey,
                     ?error("handle_loop/3",
                            [{key, binary_to_list(Key_1)},
                             {index, Index}, {cause, Cause}]),
-                    {error, Cause}
+                    erlang:error(Cause)
             end;
 
         %%
@@ -262,13 +262,13 @@ handle_loop(Index, TotalChunkObjs, #req_info{key = AcctualKey,
                     ?error("handle_loop/3",
                            [{key, binary_to_list(Key_1)},
                             {index, Index}, {cause, Cause}]),
-                    {error, Cause}
+                    erlang:error(Cause)
             end;
         {error, Cause} ->
             ?error("handle_loop/3",
                    [{key, binary_to_list(Key_1)},
                     {index, Index}, {cause, Cause}]),
-            {error, Cause}
+            erlang:error(Cause)
     end.
 
 


### PR DESCRIPTION
TCP Connection get reset immediately with additional error lines like below
```erlang
[E]     gateway_0@127.0.0.1     2017-11-30 13:42:54.829985 +0900        1512016974      null:null       0       gen_server <0.1978.0> terminated with reason: not_found in leo_large_object_get_handler:handle_loop/3 line 271
[E]     gateway_0@127.0.0.1     2017-11-30 13:42:54.830155 +0900        1512016974      null:null       0       CRASH REPORT Process <0.1978.0> with 1 neighbours exited with reason: not_found in leo_large_object_get_handler:handle_loop/3 line 271 in gen_server:terminate/7 line 812
[E]     gateway_0@127.0.0.1     2017-11-30 13:42:54.830338 +0900        1512016974      null:null       0       Ranch listener leo_gateway_s3_api terminated with reason: not_found in leo_large_object_get_handler:handle_loop/3 line 271
```