### PR TITLE
Remove bashism from Makefile (fix Debian/Ubuntu/FreeBSD build)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ sd_notify:
 	make -C deps/sd_notify
 reltool:
 	for reltool_config in rel/leo_*/reltool.config.in; do \
-		./make_reltool.sh $(with_sd_notify) $$reltool_config > $${reltool_config/.in/}; \
+		./make_reltool.sh $(with_sd_notify) $$reltool_config > $$(echo $$reltool_config | sed s/.in$$//); \
 	done
 release: reltool
 	@./rebar compile


### PR DESCRIPTION
#953 added a bashism which breaks build on certain systems (e.g. Debian and Ubuntu with "dash" shell).
Alternative solution would be using SHELL=/bin/bash in Makefile but that would bring some change for FreeBSD and Solaris systems, I think it's better to just remove it.