### PR TITLE
storage: Fix for #543 and #546

### DIFF
--- a/apps/leo_storage/rebar.config
+++ b/apps/leo_storage/rebar.config
@@ -24,14 +24,14 @@
 
 {deps, [
         {leo_commons,           ".*", {git, "https://github.com/leo-project/leo_commons.git",           {tag, "1.1.13"}}},
-        {leo_logger,            ".*", {git, "https://github.com/leo-project/leo_logger.git",            {tag, "1.3.4"}}},
-        {leo_mq,                ".*", {git, "https://github.com/leo-project/leo_mq.git",                {tag, "1.5.12"}}},
-        {leo_object_storage,    ".*", {git, "https://github.com/leo-project/leo_object_storage.git",    {tag, "1.3.21"}}},
-        {leo_ordning_reda,      ".*", {git, "https://github.com/leo-project/leo_ordning_reda.git",      {tag, "1.2.8"}}},
-        {leo_redundant_manager, ".*", {git, "https://github.com/leo-project/leo_redundant_manager.git", {tag, "1.9.55"}}},
-        {leo_rpc,               ".*", {git, "https://github.com/leo-project/leo_rpc.git",               {tag, "0.10.15"}}},
+        {leo_logger,            ".*", {git, "https://github.com/leo-project/leo_logger.git",            {tag, "1.3.5"}}},
+        {leo_mq,                ".*", {git, "https://github.com/leo-project/leo_mq.git",                {tag, "1.5.13"}}},
+        {leo_object_storage,    ".*", {git, "https://github.com/leo-project/leo_object_storage.git",    {tag, "1.3.22"}}},
+        {leo_ordning_reda,      ".*", {git, "https://github.com/leo-project/leo_ordning_reda.git",      {tag, "1.2.9"}}},
+        {leo_redundant_manager, ".*", {git, "https://github.com/leo-project/leo_redundant_manager.git", {tag, "1.9.56"}}},
+        {leo_rpc,               ".*", {git, "https://github.com/leo-project/leo_rpc.git",               {tag, "0.10.16"}}},
         {leo_statistics,        ".*", {git, "https://github.com/leo-project/leo_statistics.git",        {tag, "1.1.20"}}},
-        {leo_watchdog,          ".*", {git, "https://github.com/leo-project/leo_watchdog.git",          {tag, "1.0.4"}}},
+        {leo_watchdog,          ".*", {git, "https://github.com/leo-project/leo_watchdog.git",          {tag, "1.0.5"}}},
         {meck,                  ".*", {git, "https://github.com/eproxus/meck.git",                      {tag, "0.8.6"}}},
         {sd_notify,             ".*", {git, "https://github.com/systemd/erlang-sd_notify.git",          {tag, "v1.0"}}, [raw]}
        ]}.

--- a/apps/leo_storage/src/leo_storage_mq.erl
+++ b/apps/leo_storage/src/leo_storage_mq.erl
@@ -771,11 +771,12 @@ correct_redundancies_1(Key, AddrId, [#redundant_node{node = Node}|T], Metadatas,
         {ok, #member{state = ?STATE_RUNNING}} ->
             %% Retrieve a metadata from remote-node
             %% invoke head with NO retry option
-            RPCKey = rpc:async_call(Node, leo_storage_handler_object,
-                                    head, [AddrId, Key, false]),
+            RPCKey = rpc:async_call(Node, leo_object_storage_api,
+                                    head_with_check_avs, [{AddrId, Key}, check_header]),
 
             case rpc:nb_yield(RPCKey, ?DEF_REQ_TIMEOUT) of
-                {value, {ok, Metadata}} ->
+                {value, {ok, MetaBin}} ->
+                    Metadata = binary_to_term(MetaBin),
                     correct_redundancies_1(Key, AddrId, T,
                                            [{Node, Metadata}|Metadatas], ErrorNodes);
                 _Error ->

--- a/apps/leo_storage/test/leo_storage_mq_tests.erl
+++ b/apps/leo_storage/test/leo_storage_mq_tests.erl
@@ -273,6 +273,11 @@ subscribe_1_({Test0Node, Test1Node}) ->
                                             fun(_InconsistentNodes, _CorrectMetadata) ->
                                                     ok
                                             end]),
+    ok = rpc:call(Test1Node, meck, new,    [leo_object_storage_api, [no_link, non_strict]]),
+    ok = rpc:call(Test1Node, meck, expect, [leo_object_storage_api, head_with_check_avs,
+                                            fun(_AddrIdAndKey, _CheckMethod) ->
+                                                    {error, invalid_object}
+                                            end]),
     meck:expect(leo_redundant_manager_api, get_member_by_node,
                 fun(_Node) ->
                         {ok, #member{state = ?STATE_RUNNING}}
@@ -281,6 +286,10 @@ subscribe_1_({Test0Node, Test1Node}) ->
     meck:new(leo_object_storage_api, [non_strict]),
     meck:expect(leo_object_storage_api, head,
                 fun({_AddrId, _Key}) ->
+                        {ok, term_to_binary(#?METADATA{num_of_replicas = 0})}
+                end),
+    meck:expect(leo_object_storage_api, head_with_check_avs,
+                fun({_AddrId, _Key}, _CheckMethod) ->
                         {ok, term_to_binary(#?METADATA{num_of_replicas = 0})}
                 end),
 


### PR DESCRIPTION
Should be merged after https://github.com/leo-project/leo_object_storage/pull/20 got merged.
and also just happens to notice now recover-node also doesn't work in case metadata is valid and avs is broken. I will update PR later for that. (leo_sync_local_cluster:store/2 has to deal with the case using leo_object_storage_api:head_with_check_avs)