### PR TITLE
Make "make_reltool.sh" more portable

### DIFF
--- a/make_reltool.sh
+++ b/make_reltool.sh
@@ -1,11 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 
 # requires first parameter to be either "yes" or "no", which is done by "make reltool"
 with_sd_notify=$1
 
 sed "
-1 i\%% CAUTION: Don't edit this file as it's automatically generated through \"make release\"
-1 i\%% Edit \"reltool.config.in\" instead\n
+1 i\\
+%% CAUTION: Don't edit this file as it's automatically generated through \"make release\"
+1 i\\
+%% Edit \"reltool.config.in\" instead
 b $with_sd_notify
 :yes
 s/%% SD_NOTIFY_PLACEHOLDER/,{app, sd_notify,             [{incl_cond, include}]}/


### PR DESCRIPTION
Works correctly on non-Linux systems now (tested on FreeBSD 10 and Solaris 11.3).