### PR TITLE
storage: Fix #989

### DIFF
--- a/apps/leo_storage/src/leo_storage_handler_object.erl
+++ b/apps/leo_storage/src/leo_storage_handler_object.erl
@@ -1221,11 +1221,21 @@ read_and_repair_1(_,[],_, false, Errors) ->
         false ->
             {error, not_found};
         _ ->
+            %% dispatch the below function to check if the errors is unavailable(503) or not.
+            read_and_repair_1(void, [], void, true, Errors)
+    end;
+read_and_repair_1(_,[],_,_, Errors) ->
+    case lists:all(fun(unavailable) ->
+                           true;
+                      (_) ->
+                           false
+                   end, Errors) of
+        true ->
+            {error, unavailable};
+        false ->
             %% If some nodes are missing, reply the state is uncertain
             {error, ?ERROR_RECOVER_FAILURE}
     end;
-read_and_repair_1(_,[],_,_,_) ->
-    {error, ?ERROR_RECOVER_FAILURE};
 read_and_repair_1(ReadParams, [Node|Rest], AvailableNodes, HasUnavailableNodes, Errors) ->
     case read_and_repair_2(ReadParams, Node, AvailableNodes) of
         {error, Cause} ->


### PR DESCRIPTION
Fixed https://github.com/leo-project/leofs/issues/989.
Confirmed with 
- object_storage.threshold_of_slow_processing = 300
- watchdog.msgs.is_enabled = true

in leo_storage.conf and basho_benched to yield {error, unavailable}.