### PR TITLE
manager: Resolve leo-project/leofs/issues/1003

### DIFF
--- a/apps/leo_manager/include/leo_manager.hrl
+++ b/apps/leo_manager/include/leo_manager.hrl
@@ -324,6 +324,7 @@
 -define(ERROR_COULD_NOT_GET_CLUSTER_INFO,"Could not get cluster info").
 -define(ERROR_OVER_MAX_CLUSTERS, "Over max number of clusters").
 -define(ERROR_CLUSTER_NOT_FOUND, "Cluster not found").
+-define(ERROR_NOT_REMOTE_CLUSTER, "Not remote cluster").
 -define(ERROR_UPDATED_SYSTEM_CONF, "Updated the system configuration").
 -define(ERROR_FAILED_UPDATE_LOG_LEVEL, "Failed to update the log-level").
 -define(ERROR_FAILED_GET_VERSION, "Failed to get the version").


### PR DESCRIPTION
LeoManager rejects a request of `recover-cluster <CLUSTER_ID>` when not joining a remote cluster as below:

```
$ ./leofs-adm status
 [System Confiuration]
-----------------------------------+----------
 Item                              | Value
-----------------------------------+----------
 Basic/Consistency level
-----------------------------------+----------
                    system version | 1.4.0
                        cluster Id | leofs_1
                             DC Id | dc_1
                    Total replicas | 1
          number of successes of R | 1
          number of successes of W | 1
          number of successes of D | 1
 number of rack-awareness replicas | 0
                         ring size | 2^128
-----------------------------------+----------
 Multi DC replication settings
-----------------------------------+----------
 [mdcr] max number of joinable DCs | 2
 [mdcr] total replicas per a DC    | 1
 [mdcr] number of successes of R   | 1
 [mdcr] number of successes of W   | 1
 [mdcr] number of successes of D   | 1
-----------------------------------+----------
 Manager RING hash
-----------------------------------+----------
                 current ring-hash | 433fe365
                previous ring-hash | 433fe365
-----------------------------------+----------

 [State of Node(s)]
-------+--------------------------+--------------+----------------+----------------+----------------------------
 type  |           node           |    state     |  current ring  |   prev ring    |          updated at
-------+--------------------------+--------------+----------------+----------------+----------------------------
  S    | storage_0@127.0.0.1      | running      | 433fe365       | 433fe365       | 2018-03-19 12:51:00 +0900
  G    | gateway_0@127.0.0.1      | running      | 433fe365       | 433fe365       | 2018-03-19 12:51:02 +0900
-------+--------------------------+--------------+----------------+----------------+----------------------------

$ ./leofs-adm recover-cluster leofs_1
[ERROR] Not remote cluster

$ ./leofs-adm recover-cluster leofs_2
[ERROR] Cluster not found
```