### PR TITLE
[leofs] To be able to correctly terminate leofs-adm's commads on Ubuntu-18.04

### DIFF
--- a/leofs-adm
+++ b/leofs-adm
@@ -5,7 +5,7 @@
 #
 # LeoFS
 #
-# Copyright (c) 2012-2015 Rakuten, Inc.
+# Copyright (c) 2012-2018 Rakuten, Inc.
 #
 # This file is provided to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file
@@ -66,6 +66,14 @@ case $OS in
         ;;
     SunOS)
         NC_ARGS=""
+        ;;
+    Linux)
+        ## For Ubuntu-18.04
+        if cat /etc/issue | grep -q 'Ubuntu Bionic'; then
+            NC_ARGS="-N"
+        else
+            NC_ARGS="-C"
+        fi
         ;;
     *)
         NC_ARGS="-C"

--- a/leofs-adm
+++ b/leofs-adm
@@ -68,8 +68,11 @@ case $OS in
         NC_ARGS=""
         ;;
     Linux)
+        DIST_ID=`lsb_release -is`
+        RELEASE_NUM=`lsb_release -rs`
+
         ## For Ubuntu-18.04
-        if cat /etc/issue | grep -q 'Ubuntu Bionic'; then
+        if [ "$DIST_ID" = "Ubuntu" -a "$RELEASE_NUM" = "18.04" ]; then
             NC_ARGS="-N"
         else
             NC_ARGS="-C"


### PR DESCRIPTION
I've found `leofs-adm` commands cannot terminate on Ubuntu-18.04.