### PR TITLE
Modify rack-awareness replication related functions

### DIFF
--- a/apps/leo_gateway/rebar.config
+++ b/apps/leo_gateway/rebar.config
@@ -28,7 +28,7 @@
         {leo_logger,            ".*", {git, "https://github.com/leo-project/leo_logger.git",            {tag, "1.3.7"}}},
         {leo_object_storage,    ".*", {git, "https://github.com/leo-project/leo_object_storage.git",    {tag, "1.3.34"}}},
         {leo_pod,               ".*", {git, "https://github.com/leo-project/leo_pod.git",               {tag, "0.6.9"}}},
-        {leo_redundant_manager, ".*", {git, "https://github.com/leo-project/leo_redundant_manager.git", {tag, "1.9.60"}}},
+        {leo_redundant_manager, ".*", {git, "https://github.com/leo-project/leo_redundant_manager.git", {tag, "1.9.61"}}},
         {leo_statistics,        ".*", {git, "https://github.com/leo-project/leo_statistics.git",        {tag, "1.1.22"}}},
         {leo_s3_libs,           ".*", {git, "https://github.com/leo-project/leo_s3_libs.git",           {tag, "1.2.19"}}},
         {leo_watchdog,          ".*", {git, "https://github.com/leo-project/leo_watchdog.git",          {tag, "1.0.6"}}},

--- a/apps/leo_manager/include/leo_manager.hrl
+++ b/apps/leo_manager/include/leo_manager.hrl
@@ -2,7 +2,7 @@
 %%
 %% Leo Manager
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -408,41 +408,53 @@
                 ?AUTH_DONE).
 
 -ifdef(TEST).
--record(state, {formatter :: atom(),
-                auth = ?AUTH_DONE :: auth(),
-                user_id = <<>> :: binary(),
-                password = <<>> :: binary(),
-                plugin_mod :: atom()
-               }).
+-record(state,
+        {formatter :: atom(),
+         auth = ?AUTH_DONE :: auth(),
+         user_id = <<>> :: binary(),
+         password = <<>> :: binary(),
+         plugin_mod :: atom()
+        }).
 -else.
--record(state, {formatter :: atom(),
-                auth = ?AUTH_DONE :: auth(),
-                user_id = <<>> :: binary(),
-                password = <<>> :: binary(),
-                plugin_mod :: atom()
-               }).
+-record(state,
+        {formatter :: atom(),
+         auth = ?AUTH_DONE :: auth(),
+         user_id = <<>> :: binary(),
+         password = <<>> :: binary(),
+         plugin_mod :: atom()
+        }).
 -endif.
 
--record(rebalance_info, {
-          vnode_id = -1  :: integer(),
-          node :: atom(),
-          total_of_objects = 0 :: integer(),
-          num_of_remains = 0 :: integer(),
-          when_is = 0 :: integer() %% Posted at
-         }).
+-record(rebalance_info,
+        {vnode_id = -1  :: integer(),
+         node :: atom(),
+         total_of_objects = 0 :: integer(),
+         num_of_remains = 0 :: integer(),
+         when_is = 0 :: integer() %% Posted at
+        }).
 
--record(history, {
-          id = 1 :: pos_integer(),
-          command = [] :: string(), %% Command
-          created = -1 :: integer() %% Created At
-         }).
+-record(history,
+        {id = 1 :: pos_integer(),
+         command = [] :: string(), %% Command
+         created = -1 :: integer() %% Created At
+        }).
 
--record(recovery_rebalance_info, {
-          id = 1 :: pos_integer(),
-          node :: atom(),
-          rebalance_info = [] :: list(tuple()),
-          timestamp = 1 :: pos_integer()
-         }).
+-record(recovery_rebalance_info,
+        {id = 1 :: pos_integer(),
+         node :: atom(),
+         rebalance_info = [] :: list(tuple()),
+         timestamp = 1 :: pos_integer()
+        }).
+
+-record(node_state_for_output,
+        {node = [] :: string(),
+         type = [] :: string(),
+         state :: atom(),
+         group = [] :: string(),
+         ring_hash_new = [] :: string(),
+         ring_hash_old = [] :: string(),
+         when_is = 0 :: non_neg_integer()
+        }).
 
 
 -define(STATE_INVALID, 0).
@@ -454,32 +466,32 @@
                             ?STATE_ENQUEUING |
                             ?STATE_MONITORING |
                             ?STATE_FINISHED).
--record(del_bucket_queue, {
-          bucket_name = <<>> :: binary(),
-          access_key_bin = <<>> :: binary(),
-          state = ?STATE_PENDING :: del_bucket_state(),
-          timestamp = 1 :: pos_integer()
-         }).
+-record(del_bucket_queue,
+        {bucket_name = <<>> :: binary(),
+         access_key_bin = <<>> :: binary(),
+         state = ?STATE_PENDING :: del_bucket_state(),
+         timestamp = 1 :: pos_integer()
+        }).
 
--record(del_bucket_state, {
-          id = <<>> :: binary(),
-          bucket_name = <<>> :: binary(),
-          node :: atom(),
-          state = ?STATE_PENDING :: del_bucket_state(),
-          timestamp = 1 :: pos_integer()
-         }).
+-record(del_bucket_state,
+        {id = <<>> :: binary(),
+         bucket_name = <<>> :: binary(),
+         node :: atom(),
+         state = ?STATE_PENDING :: del_bucket_state(),
+         timestamp = 1 :: pos_integer()
+        }).
 
 -define(NODE_TYPE_GATEWAY, 0).
 -define(NODE_TYPE_STORAGE, 1).
 -type(dest_node_type() :: ?NODE_TYPE_GATEWAY |
                           ?NODE_TYPE_STORAGE).
--record(del_bucket_request, {
-          id = 1 :: pos_integer(),
-          node_type = ?NODE_TYPE_GATEWAY :: dest_node_type(),
-          bucket_name = <<>> :: binary(),
-          node :: node(),
-          timestamp = 1 :: pos_integer()
-         }).
+-record(del_bucket_request,
+        {id = 1 :: pos_integer(),
+         node_type = ?NODE_TYPE_GATEWAY :: dest_node_type(),
+         bucket_name = <<>> :: binary(),
+         node :: node(),
+         timestamp = 1 :: pos_integer()
+        }).
 
 
 -define(del_bucket_state(_State),

--- a/apps/leo_manager/include/leo_manager.hrl
+++ b/apps/leo_manager/include/leo_manager.hrl
@@ -450,7 +450,7 @@
         {node = [] :: string(),
          type = [] :: string(),
          state :: atom(),
-         group = [] :: string(),
+         rack_id = [] :: string(),
          ring_hash_new = [] :: string(),
          ring_hash_old = [] :: string(),
          when_is = 0 :: non_neg_integer()

--- a/apps/leo_manager/rebar.config
+++ b/apps/leo_manager/rebar.config
@@ -26,7 +26,7 @@
         {leo_commons,           ".*", {git, "https://github.com/leo-project/leo_commons.git",           {tag, "1.2.0"}}},
         {leo_logger,            ".*", {git, "https://github.com/leo-project/leo_logger.git",            {tag, "1.3.7"}}},
         {leo_object_storage,    ".*", {git, "https://github.com/leo-project/leo_object_storage.git",    {tag, "1.3.34"}}},
-        {leo_redundant_manager, ".*", {git, "https://github.com/leo-project/leo_redundant_manager.git", {tag, "1.9.60"}}},
+        {leo_redundant_manager, ".*", {git, "https://github.com/leo-project/leo_redundant_manager.git", {tag, "1.9.61"}}},
         {leo_statistics,        ".*", {git, "https://github.com/leo-project/leo_statistics.git",        {tag, "1.1.22"}}},
         {leo_s3_libs,           ".*", {git, "https://github.com/leo-project/leo_s3_libs.git",           {tag, "1.2.19"}}},
         {jiffy,                 ".*", {git, "https://github.com/davisp/jiffy.git",                      {tag, "0.14.8"}}},

--- a/apps/leo_manager/src/leo_manager_console.erl
+++ b/apps/leo_manager/src/leo_manager_console.erl
@@ -1591,11 +1591,11 @@ status(node_list) ->
                      {ok, R1} ->
                          lists:map(fun(N) ->
                                            Node = N#node_state.node,
-                                           {State, Grp} =
+                                           {State, RackId} =
                                                case leo_redundant_manager_api:get_member_by_node(Node) of
                                                    {ok, #member{state = State_1,
-                                                                grp_level_2 = Grp_1}} ->
-                                                       {State_1, Grp_1};
+                                                                grp_level_2 = RackId_1}} ->
+                                                       {State_1, RackId_1};
                                                    _ ->
                                                        error
                                                end,
@@ -1603,7 +1603,7 @@ status(node_list) ->
                                               node = atom_to_list(Node),
                                               type = ?SERVER_TYPE_STORAGE,
                                               state = atom_to_list(State),
-                                              group = Grp,
+                                              rack_id = RackId,
                                               ring_hash_new = N#node_state.ring_hash_new,
                                               ring_hash_old = N#node_state.ring_hash_old,
                                               when_is = N#node_state.when_is

--- a/apps/leo_manager/src/leo_manager_formatter_json.erl
+++ b/apps/leo_manager/src/leo_manager_formatter_json.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoManager
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -123,29 +123,42 @@ bad_nodes(BadNodes) ->
              binary()).
 system_info_and_nodes_stat(Props) ->
     SystemConf = leo_misc:get_value('system_config', Props),
-    Version    = leo_misc:get_value('version',       Props),
-    [RH0, RH1] = leo_misc:get_value('ring_hash',     Props),
-    Nodes      = leo_misc:get_value('nodes',         Props),
+    Version    = leo_misc:get_value('version', Props),
+    [RH0, RH1] = leo_misc:get_value('ring_hash', Props),
+    Nodes      = leo_misc:get_value('nodes', Props),
 
     NodeInfo = case Nodes of
                    [] -> [];
                    _  ->
                        lists:map(
-                         fun({Type, NodeName, NodeState, RingHash0, RingHash1, When}) ->
-                                 NewRingHash0 = case is_integer(RingHash0) of
-                                                    true  -> integer_to_list(RingHash0);
-                                                    false -> RingHash0
-                                                end,
-                                 NewRingHash1 = case is_integer(RingHash1) of
-                                                    true  -> integer_to_list(RingHash1);
-                                                    false -> RingHash1
-                                                end,
-                                 {[{<<"type">>,      leo_misc:any_to_binary(Type)},
-                                   {<<"node">>,      leo_misc:any_to_binary(NodeName)},
-                                   {<<"state">>,     leo_misc:any_to_binary(NodeState)},
-                                   {<<"ring_cur">>,  leo_misc:any_to_binary(NewRingHash0)},
-                                   {<<"ring_prev">>, leo_misc:any_to_binary(NewRingHash1)},
-                                   {<<"when">>,      leo_misc:any_to_binary(leo_date:date_format(When))}
+                         fun(#node_state_for_output{
+                                node = Node,
+                                type = Type,
+                                state = State,
+                                group = Group,
+                                ring_hash_new = RingHashNew,
+                                ring_hash_old = RingHashOld,
+                                when_is = When}
+                            ) ->
+                                 RingHashNew_1 = case is_integer(RingHashNew) of
+                                                     true ->
+                                                         integer_to_list(RingHashNew);
+                                                     false ->
+                                                         RingHashNew
+                                                 end,
+                                 RingHashOld_1 = case is_integer(RingHashOld) of
+                                                     true ->
+                                                         integer_to_list(RingHashOld);
+                                                     false ->
+                                                         RingHashOld
+                                                 end,
+                                 {[{<<"type">>, leo_misc:any_to_binary(Type)},
+                                   {<<"node">>, leo_misc:any_to_binary(Node)},
+                                   {<<"state">>, leo_misc:any_to_binary(State)},
+                                   {<<"group">>, leo_misc:any_to_binary(Group)},
+                                   {<<"ring_cur">>, leo_misc:any_to_binary(RingHashNew_1)},
+                                   {<<"ring_prev">>, leo_misc:any_to_binary(RingHashOld_1)},
+                                   {<<"when">>, leo_misc:any_to_binary(leo_date:date_format(When))}
                                   ]}
                          end, Nodes)
                end,
@@ -156,9 +169,9 @@ system_info_and_nodes_stat(Props) ->
     DCId_2 = atom_to_list(DCId_1),
 
     gen_json({[{<<"system_info">>,
-                {[{<<"version">>,    leo_misc:any_to_binary(Version)},
+                {[{<<"version">>, leo_misc:any_to_binary(Version)},
                   {<<"cluster_id">>, leo_misc:any_to_binary(ClusterId_2)},
-                  {<<"dc_id">>,      leo_misc:any_to_binary(DCId_2)},
+                  {<<"dc_id">>, leo_misc:any_to_binary(DCId_2)},
                   {<<"n">>, SystemConf#?SYSTEM_CONF.n},
                   {<<"r">>, SystemConf#?SYSTEM_CONF.r},
                   {<<"w">>, SystemConf#?SYSTEM_CONF.w},
@@ -170,8 +183,8 @@ system_info_and_nodes_stat(Props) ->
                   {<<"mdcr_w">>, SystemConf#?SYSTEM_CONF.mdcr_w},
                   {<<"mdcr_d">>, SystemConf#?SYSTEM_CONF.mdcr_d},
                   {<<"rack_awareness_replicas">>, SystemConf#?SYSTEM_CONF.num_of_rack_replicas},
-                  {<<"ring_size">>,      SystemConf#?SYSTEM_CONF.bit_of_ring},
-                  {<<"ring_hash_cur">>,  RH0},
+                  {<<"ring_size">>,SystemConf#?SYSTEM_CONF.bit_of_ring},
+                  {<<"ring_hash_cur">>, RH0},
                   {<<"ring_hash_prev">>, RH1},
                   {<<"max_mdc_targets">>,SystemConf#?SYSTEM_CONF.max_mdc_targets}
                  ]}},

--- a/apps/leo_manager/src/leo_manager_formatter_json.erl
+++ b/apps/leo_manager/src/leo_manager_formatter_json.erl
@@ -123,9 +123,9 @@ bad_nodes(BadNodes) ->
              binary()).
 system_info_and_nodes_stat(Props) ->
     SystemConf = leo_misc:get_value('system_config', Props),
-    Version    = leo_misc:get_value('version', Props),
+    Version = leo_misc:get_value('version', Props),
     [RH0, RH1] = leo_misc:get_value('ring_hash', Props),
-    Nodes      = leo_misc:get_value('nodes', Props),
+    Nodes = leo_misc:get_value('nodes', Props),
 
     NodeInfo = case Nodes of
                    [] -> [];
@@ -135,7 +135,7 @@ system_info_and_nodes_stat(Props) ->
                                 node = Node,
                                 type = Type,
                                 state = State,
-                                group = Group,
+                                rack_id = RackId,
                                 ring_hash_new = RingHashNew,
                                 ring_hash_old = RingHashOld,
                                 when_is = When}
@@ -155,7 +155,7 @@ system_info_and_nodes_stat(Props) ->
                                  {[{<<"type">>, leo_misc:any_to_binary(Type)},
                                    {<<"node">>, leo_misc:any_to_binary(Node)},
                                    {<<"state">>, leo_misc:any_to_binary(State)},
-                                   {<<"group">>, leo_misc:any_to_binary(Group)},
+                                   {<<"rack_id">>, leo_misc:any_to_binary(RackId)},
                                    {<<"ring_cur">>, leo_misc:any_to_binary(RingHashNew_1)},
                                    {<<"ring_prev">>, leo_misc:any_to_binary(RingHashOld_1)},
                                    {<<"when">>, leo_misc:any_to_binary(leo_date:date_format(When))}
@@ -309,7 +309,9 @@ node_stat(?SERVER_TYPE_STORAGE, State) ->
     gen_json({[{<<"node_stat">>,
                 {[{<<"version">>,          leo_misc:any_to_binary(Version)},
                   {<<"num_of_vnodes">>,    NumOfVNodes},
+                  %% @deplicated
                   {<<"grp_level_2">>,      leo_misc:any_to_binary(GrpLevel2)},
+                  {<<"rack_id">>,          leo_misc:any_to_binary(GrpLevel2)},
                   {<<"log_dir">>,          leo_misc:any_to_binary(leo_misc:get_value('log', Directories, []))},
                   {<<"ring_cur">>,         leo_misc:any_to_binary(leo_hex:integer_to_hex(leo_misc:get_value('ring_cur',  RingHashes, 0), 8))},
                   {<<"ring_prev">>,        leo_misc:any_to_binary(leo_hex:integer_to_hex(leo_misc:get_value('ring_prev', RingHashes, 0), 8))},

--- a/apps/leo_manager/src/leo_manager_formatter_text.erl
+++ b/apps/leo_manager/src/leo_manager_formatter_text.erl
@@ -290,20 +290,20 @@ system_conf_with_node_stat(FormattedSystemConf, Nodes) ->
                           end
                   end, 0, Nodes) + 5,
     Col_2_Len = lists:foldl(
-                  fun(#node_state_for_output{group = G}, Acc) ->
-                          Len = length(G),
+                  fun(#node_state_for_output{rack_id = R}, Acc) ->
+                          Len = length(R),
                           case (Len > Acc) of
                               true  ->
                                   Len;
                               false ->
                                   Acc
                           end
-                  end, 0, Nodes) + 5,
+                  end, 0, Nodes) + 7,
 
     CellColumns = [{"type", 6},
                    {"node", Col_1_Len},
                    {"state", 12},
-                   {"group", Col_2_Len},
+                   {"rack id", Col_2_Len},
                    {"current ring", 14},
                    {"prev ring", 14},
                    {"updated at", 28},
@@ -338,7 +338,7 @@ system_conf_with_node_stat(FormattedSystemConf, Nodes) ->
     Fun3 = fun(#node_state_for_output{node = Node,
                                       type = Type,
                                       state = State,
-                                      group = Group,
+                                      rack_id = RackId,
                                       ring_hash_new = RingHashNew,
                                       ring_hash_old = RingHashOld,
                                       when_is = When} = _N, List) ->
@@ -346,7 +346,7 @@ system_conf_with_node_stat(FormattedSystemConf, Nodes) ->
                    Ret = lists:append([string:centre(Type, lists:nth(1,LenPerCol)), ?SEPARATOR,
                                        string:left(Node, lists:nth(2,LenPerCol)), ?SEPARATOR,
                                        string:left(State, lists:nth(3,LenPerCol)), ?SEPARATOR,
-                                       string:left(Group, lists:nth(4,LenPerCol)), ?SEPARATOR,
+                                       string:left(RackId, lists:nth(4,LenPerCol)), ?SEPARATOR,
                                        string:left(RingHashNew, lists:nth(5,LenPerCol)), ?SEPARATOR,
                                        string:left(RingHashOld, lists:nth(6,LenPerCol)), ?SEPARATOR,
                                        FormattedDate,

--- a/apps/leo_storage/rebar.config
+++ b/apps/leo_storage/rebar.config
@@ -28,7 +28,7 @@
         {leo_mq,                ".*", {git, "https://github.com/leo-project/leo_mq.git",                {tag, "1.5.17"}}},
         {leo_object_storage,    ".*", {git, "https://github.com/leo-project/leo_object_storage.git",    {tag, "1.3.34"}}},
         {leo_ordning_reda,      ".*", {git, "https://github.com/leo-project/leo_ordning_reda.git",      {tag, "1.2.10"}}},
-        {leo_redundant_manager, ".*", {git, "https://github.com/leo-project/leo_redundant_manager.git", {tag, "1.9.60"}}},
+        {leo_redundant_manager, ".*", {git, "https://github.com/leo-project/leo_redundant_manager.git", {tag, "1.9.61"}}},
         {leo_statistics,        ".*", {git, "https://github.com/leo-project/leo_statistics.git",        {tag, "1.1.22"}}},
         {leo_watchdog,          ".*", {git, "https://github.com/leo-project/leo_watchdog.git",          {tag, "1.0.6"}}},
         {meck,                  ".*", {git, "https://github.com/eproxus/meck.git",                      {tag, "0.8.6"}}},

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@
 #
 # LeoFS
 #
-# Copyright (c) 2012-2017 Rakuten, Inc.
+# Copyright (c) 2012-2018 Rakuten, Inc.
 #
 # This file is provided to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file
@@ -20,23 +20,33 @@
 # under the License.
 #
 #======================================================================
-echo "*** LeoFS - Start building test-environment ***"
+TEST_INTEGRATION="integration-test"
+TEST_WATCHDOG="watchdog-test"
+TEST_CACHE="cache-test"
+TEST_HTTP_CACHE="http-cache-test"
+TEST_RACK_AWARENESS="rack-awareness-test"
+USAGE="Usage: bootstrap build|start|stop $TEST_INTEGRATION|$TEST_WATCHDOG|$TEST_CACHE|$TEST_HTTP_CACHE|$TEST_RACK_AWARENESS"
+ERROR_MSG="No command to run specified!"
 
 if [ $# -ne 2 ]; then
-    echo "No command to run specified!"
-    echo "Usage: bootstrap build|start|stop integration-test|watchdog-test|cache-test|http-cache-test"
+    echo $ERROR_MSG
+    echo $USAGE
     exit 1
 fi
 
 if [ $1 != "build" -a $1 != "start" -a $1 != "stop" ]; then
-    echo "No command to run specified!"
-    echo "Usage: bootstrap build|start|stop integration-test|watchdog-test|cache-test|http-cache-test"
+    echo $ERROR_MSG
+    echo $USAGE
     exit 1
 fi
 
-if [ $2 != "integration-test" -a $2 != "watchdog-test" -a $2 != "cache-test" -a $2 != "http-cache-test" ]; then
-    echo "No command to run specified!"
-    echo "Usage: bootstrap build|start|stop integration-test|watchdog-test|cache-test|http-cache-test"
+if [ $2 != "$TEST_INTEGRATION" -a \
+     $2 != "$TEST_WATCHDOG" -a \
+     $2 != "$TEST_CACHE" -a \
+     $2 != "$TEST_HTTP_CACHE" -a \
+     $2 != "$TEST_RACK_AWARENESS" ]; then
+    echo $ERROR_MSG
+    echo $USAGE
     exit 1
 fi
 
@@ -66,7 +76,7 @@ cp -r package/leo_gateway package/leo_gateway_0
 rm -rf package/leo_storage
 rm -rf package/leo_gateway
 
-if [ $2 = "integration-test" ]; then
+if [ $2 = "$TEST_INTEGRATION" ]; then
     cp priv/test/integration-test/app-m0.conf package/leo_manager_0/etc/leo_manager.conf
     cp priv/test/integration-test/app-m1.conf package/leo_manager_1/etc/leo_manager.conf
     cp priv/test/integration-test/app-s0.conf package/leo_storage_0/etc/leo_storage.conf
@@ -75,7 +85,7 @@ if [ $2 = "integration-test" ]; then
     cp priv/test/integration-test/app-s3.conf package/leo_storage_3/etc/leo_storage.conf
     cp priv/test/integration-test/app-s4.conf package/leo_storage_4/etc/leo_storage.conf
     cp priv/test/integration-test/app-g0.conf package/leo_gateway_0/etc/leo_gateway.conf
-elif [ $2 = "watchdog-test" ]; then
+elif [ $2 = "$TEST_WATCHDOG" ]; then
     cp priv/test/watchdog-test/app-m0.conf package/leo_manager_0/etc/leo_manager.conf
     cp priv/test/watchdog-test/app-m1.conf package/leo_manager_1/etc/leo_manager.conf
     cp priv/test/watchdog-test/app-s0.conf package/leo_storage_0/etc/leo_storage.conf
@@ -83,7 +93,7 @@ elif [ $2 = "watchdog-test" ]; then
     cp priv/test/watchdog-test/app-s2.conf package/leo_storage_2/etc/leo_storage.conf
     cp priv/test/watchdog-test/app-s3.conf package/leo_storage_3/etc/leo_storage.conf
     cp priv/test/watchdog-test/app-s4.conf package/leo_storage_4/etc/leo_storage.conf
-elif [ $2 = "cache-test" ]; then
+elif [ $2 = "$TEST_CACHE" ]; then
     cp priv/test/cache-test/app-m0.conf package/leo_manager_0/etc/leo_manager.conf
     cp priv/test/cache-test/app-m1.conf package/leo_manager_1/etc/leo_manager.conf
     cp priv/test/cache-test/app-s0.conf package/leo_storage_0/etc/leo_storage.conf
@@ -92,7 +102,7 @@ elif [ $2 = "cache-test" ]; then
     cp priv/test/cache-test/app-s3.conf package/leo_storage_3/etc/leo_storage.conf
     cp priv/test/cache-test/app-s4.conf package/leo_storage_4/etc/leo_storage.conf
     cp priv/test/cache-test/app-g0.conf package/leo_gateway_0/etc/leo_gateway.conf
-else
+elif [ $2 = "$TEST_HTTP_CACHE" ]; then
     cp priv/test/http-cache-test/app-m0.conf package/leo_manager_0/etc/leo_manager.conf
     cp priv/test/http-cache-test/app-m1.conf package/leo_manager_1/etc/leo_manager.conf
     cp priv/test/http-cache-test/app-s0.conf package/leo_storage_0/etc/leo_storage.conf
@@ -101,6 +111,17 @@ else
     cp priv/test/http-cache-test/app-s3.conf package/leo_storage_3/etc/leo_storage.conf
     cp priv/test/http-cache-test/app-s4.conf package/leo_storage_4/etc/leo_storage.conf
     cp priv/test/http-cache-test/app-g0.conf package/leo_gateway_0/etc/leo_gateway.conf
+elif [ $2 = "$TEST_RACK_AWARENESS" ]; then
+    cp priv/test/rack-awareness-test/app-m0.conf package/leo_manager_0/etc/leo_manager.conf
+    cp priv/test/rack-awareness-test/app-m1.conf package/leo_manager_1/etc/leo_manager.conf
+    cp priv/test/rack-awareness-test/app-s0.conf package/leo_storage_0/etc/leo_storage.conf
+    cp priv/test/rack-awareness-test/app-s1.conf package/leo_storage_1/etc/leo_storage.conf
+    cp priv/test/rack-awareness-test/app-s2.conf package/leo_storage_2/etc/leo_storage.conf
+    cp priv/test/rack-awareness-test/app-s3.conf package/leo_storage_3/etc/leo_storage.conf
+    cp priv/test/rack-awareness-test/app-s3.conf package/leo_storage_3/etc/leo_storage.conf
+    cp priv/test/rack-awareness-test/app-g0.conf package/leo_gateway_0/etc/leo_gateway.conf
+else
+    exit 1
 fi
 
 ## Launch the applications
@@ -135,5 +156,3 @@ echo ":::"
 ./leofs-adm start
 sleep 1
 ./leofs-adm status
-
-echo "*** leofs - Finished :) ***"

--- a/priv/test/rack-awareness-test/app-g0.conf
+++ b/priv/test/rack-awareness-test/app-g0.conf
@@ -1,0 +1,350 @@
+#======================================================================
+# LeoFS - Gateway Configuration
+#======================================================================
+## --------------------------------------------------------------------
+## SASL
+## --------------------------------------------------------------------
+## See: http://www.erlang.org/doc/man/sasl_app.html
+##
+## The following configuration parameters are defined for
+## the SASL application. See app(4) for more information
+## about configuration parameters
+
+## SASL error log path
+## sasl.sasl_error_log = ./log/sasl/sasl-error.log
+
+## Restricts the error logging performed by the specified sasl_error_logger
+## to error reports, progress reports, or both.
+## errlog_type = [error | progress | all]
+## sasl.errlog_type = error
+
+## Specifies in which directory the files are stored.
+## If this parameter is undefined or false, the error_logger_mf_h is not installed.
+# sasl.error_logger_mf_dir = ./log/sasl
+
+## Specifies how large each individual file can be.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxbytes = 10485760
+
+## Specifies how many files are used.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxfiles = 5
+
+## --------------------------------------------------------------------
+## Manager's Node(s)
+## --------------------------------------------------------------------
+## Name of Manager node(s)
+managers = [manager_0@127.0.0.1, manager_1@127.0.0.1]
+
+
+## --------------------------------------------------------------------
+## GATEWAY Protocol
+## --------------------------------------------------------------------
+## Gateway Protocol to use: [s3 | rest | embed | nfs]
+protocol = s3
+
+
+## --------------------------------------------------------------------
+## GATEWAY - HTTP-related configurations
+## --------------------------------------------------------------------
+## Port number the Gateway uses for HTTP connections
+http.port = 8080
+
+## Numbers of processes listening for connections
+http.num_of_acceptors = 128
+
+## Maximum number of requests allowed in a single keep-alive session
+http.max_keepalive = 4096
+
+## Maximum number of virtual directories
+## http.layer_of_dirs = 12
+
+## Port number the Gateway uses for HTTPS connections
+## http.ssl_port     = 8443
+
+## SSL Certificate file
+## http.ssl_certfile = ./etc/server_cert.pem
+
+## SSL key
+## http.ssl_keyfile  = ./etc/server_key.pem
+
+## HTTP custom header configuration file path
+## http.headers_config_file = ./etc/http_custom_header.conf
+
+## HTTP timeout for reading header
+## http.timeout_for_header = 5000
+
+## HTTP timeout for reading body
+## http.timeout_for_body = 15000
+
+## Synchronized time of a bucket property (second)
+bucket_prop_sync_interval = 300
+
+
+## --------------------------------------------------------------------
+## GATEWAY - NFS-related configurations
+## --------------------------------------------------------------------
+## Mountd's port number
+## nfs.mountd.port = 22050
+
+## Mountd's the number of acceptors
+## nfs.mountd.acceptors = 128
+
+## NFSd's port number
+## nfs.nfsd.port = 2049
+
+## NFSd's the number of acceptors
+## nfs.nfsd.acceptors = 128
+
+## --------------------------------------------------------------------
+## GATEWAY - Large Object
+## --------------------------------------------------------------------
+## Total number of chunked objects
+large_object.max_chunked_objs = 1000
+
+## Length of a chunked object
+large_object.chunked_obj_len = 5242880
+
+## Threshold of length of a chunked object
+large_object.threshold_of_chunk_len = 5767168
+
+## Reading length of a chuncked object
+##   * If happening timeout when copying a large object,
+##     you will solve to set this value as less than 5MB.
+##   * default: "large_object.chunked_obj_len" (5242880 - 5MB)
+large_object.reading_chunked_obj_len = 5242880
+
+
+## --------------------------------------------------------------------
+## GATEWAY - Cache
+## --------------------------------------------------------------------
+## If this parameter is 'true', Gateway turns on HTTP-based cache server, like Varnish OR Squid.
+## If this parameter is 'false', Stores objects into the Gateway’s memory.
+## When operating READ, the Etag of the cache is compared with a backend storage’s Etag.
+## cache.http_cache = false
+
+## A number of cache workers
+## cache.cache_workers = 16
+
+## Memory cache capacity in bytes
+cache.cache_ram_capacity  = 0
+
+## Disk cache capacity in bytes
+cache.cache_disc_capacity = 0
+
+## When the length of the object exceeds this value, store the object on disk
+cache.cache_disc_threshold_len = 1048576
+
+## Directory for the disk cache data
+cache.cache_disc_dir_data    = ./cache/data
+
+## Directory for the disk cache journal
+cache.cache_disc_dir_journal = ./cache/journal
+
+## Cache Expire in seconds
+cache.cache_expire = 300
+
+## Cache Max Content Length in bytes
+cache.cache_max_content_len = 1048576
+
+## Cache Content Type(s)
+## In case of "empty", all objects are cached.
+## cache.cachable_content_type =
+
+## Cache Path Pattern(s) (regular expression)
+## In case of "empty", all objects are cached.
+## cache.cachable_path_pattern =
+
+
+## --------------------------------------------------------------------
+## GATEWAY - Watchdog
+## --------------------------------------------------------------------
+##
+##  Watchdog.REX(RPC)
+##
+## Is rex -watchdog enabled - default:false
+## watchdog.rex.is_enabled = true
+
+## rex - watch interval - default:5sec
+## watchdog.rex.interval = 5
+
+## Threshold memory capacity of binary for rex(rpc) - default:32MB
+watchdog.rex.threshold_mem_capacity = 33554432
+
+
+##
+##  Watchdog.CPU
+##
+## Is cpu-watchdog enabled - default:false
+## watchdog.cpu.is_enabled = true
+
+## cpu - raised error times
+## watchdog.cpu.raised_error_times = 3
+
+## cpu - watch interval - default:5sec
+## watchdog.cpu.interval = 5
+
+## Threshold CPU load avg for 1min/5min - default:5.0
+## watchdog.cpu.threshold_cpu_load_avg = 5.0
+
+## Threshold CPU load util - default:100 = "100%"
+## watchdog.cpu.threshold_cpu_util = 100
+
+
+##
+##  Watchdog.Erlang IO
+##
+## Is io-watchdog enabled - default:false
+## watchdog.io.is_enabled = true
+
+## io - watch interval - default:1sec
+## watchdog.io.interval = 1
+
+## Threshold input size/sec  - default:128MB/sec
+## watchdog.io.threshold_input_per_sec = 134217728
+
+## Threshold output size/sec - default:128MB/sec
+## watchdog.io.threshold_output_per_sec = 134217728
+
+
+## --------------------------------------------------------------------
+## GATEWAY - Timeout
+## --------------------------------------------------------------------
+## Timeout value when requesting to a storage
+## 0 to 65,535 bytes
+## timeout.level_1 =  5000
+
+## 65,535 to 131,071 bytes
+## timeout.level_2 =  7000
+
+## 131,072 to 524,287 bytes
+## timeout.level_3 = 10000
+
+## 524,288 to 1,048,576 bytes
+## timeout.level_4 = 20000
+
+## 1,048,576 bytes and over
+## timeout.level_5 = 30000
+
+## Timeout value when requesting a GET to a storage
+## timeout.get = 30000
+
+## Timeout value when requesting a LS(find_by_parent_dir) to a storage
+## timeout.ls = 30000
+
+
+## --------------------------------------------------------------------
+## GATEWAY - Log
+## --------------------------------------------------------------------
+##
+## Log level: [0:debug, 1:info, 2:warn, 3:error]
+## log.log_level = 1
+
+## Is enable access-log [true, false]
+log.is_enable_access_log = true
+
+## Output log file(s) - Erlang's log
+## log.erlang = ./log/erlang
+
+## Output log file(s) - app
+## log.app = ./log/app
+
+## Output log file(s) - members of storage-cluster
+## log.member_dir = ./log/ring
+
+## Output log file(s) - ring
+## log.ring_dir = ./log/ring
+
+## --------------------------------------------------------------------
+## GATEWAY - Other Directories
+## --------------------------------------------------------------------
+## Directory of queue for monitoring "RING"
+## queue_dir  = ./work/queue
+
+## Directory of SNMP agent configuration
+## snmp_agent = ./snmp/snmpa_gateway_0/LEO-GATEWAY
+
+
+## --------------------------------------------------------------------
+## QoS
+## --------------------------------------------------------------------
+## Enable QoS for statistics
+## qos.stat.is_enable = false
+
+## Enable QoS for notification
+## qos.notify.is_enable = false
+
+## Savanna Manager's nodes
+## qos.managers = [savanna_manager_0@127.0.0.1, savanna_manager_1@127.0.0.1]
+
+
+## --------------------------------------------------------------------
+## Other Libs
+## --------------------------------------------------------------------
+## Enable profiler - leo_backend_db
+## leo_backend_db.profile = false
+
+## Enable profiler - leo_logger
+## leo_logger.profile = false
+
+## Enable profiler - leo_mq
+## leo_mq.profile = false
+
+## Enable profiler - leo_redundant_manager
+## leo_redundant_manager.profile = false
+
+## Enable profiler - leo_statistics
+## leo_statistics.profile = false
+
+
+#======================================================================
+# For vm.args
+#======================================================================
+## Name of the leofs-gateway node
+nodename = gateway_0@127.0.0.1
+
+## Cookie for distributed node communication.  All nodes in the same cluster
+## should use the same cookie or they will not be able to communicate.
+distributed_cookie = 401321b4
+
+## Enable kernel poll
+erlang.kernel_poll = true
+
+## Number of async threads
+erlang.asyc_threads = 32
+
+## Increase number of concurrent ports/sockets
+erlang.max_ports = 64000
+
+## Set the location of crash dumps
+erlang.crash_dump = ./log/erl_crash.dump
+
+## Raise the ETS table limit
+erlang.max_ets_tables = 256000
+
+## Enable SMP
+erlang.smp = enable
+
+## Erlang scheduler's compaction of load
+erlang.schedulers.compaction_of_load = true
+
+## Erlang scheduler's balancing of load
+erlang.schedulers.utilization_balancing = false
+
+## Sender-side network distribution buffer size
+## - default 32MB (32768KB)
+erlang.distribution_buffer_size = 32768
+
+## A non-negative integer which indicates
+## how many times generational garbage collections
+## can be done without forcing a fullsweep collection
+erlang.fullsweep_after = 0
+
+## Enable eager check I/O
+erlang.secio = false
+
+## Raise the default erlang process limit
+process_limit = 1048576
+
+## Path of SNMP-agent configuration
+##snmp_conf = ./snmp/snmpa_gateway_0/leo_gateway_snmp

--- a/priv/test/rack-awareness-test/app-m0.conf
+++ b/priv/test/rack-awareness-test/app-m0.conf
@@ -1,0 +1,195 @@
+##======================================================================
+## LeoFS - Manager Configuration (MASTER)
+#======================================================================
+## --------------------------------------------------------------------
+## SASL
+## --------------------------------------------------------------------
+## See: http://www.erlang.org/doc/man/sasl_app.html
+##
+## The following configuration parameters are defined for
+## the SASL application. See app(4) for more information
+## about configuration parameters
+
+## SASL error log path
+## sasl.sasl_error_log = ./log/sasl/sasl-error.log
+
+## Restricts the error logging performed by the specified sasl_error_logger
+## to error reports, progress reports, or both.
+## errlog_type = [error | progress | all]
+## sasl.errlog_type = error
+
+## Specifies in which directory the files are stored.
+## If this parameter is undefined or false, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_dir = ./log/sasl
+
+## Specifies how large each individual file can be.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxbytes = 10485760
+
+## Specifies how many files are used.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxfiles = 5
+
+## --------------------------------------------------------------------
+## MANAGER
+## --------------------------------------------------------------------
+## Partner of manager's alias
+manager.partner = manager_1@127.0.0.1
+
+## Manager-console accepatable port number
+console.port.cui  = 10010
+console.port.json = 10020
+
+## Manager-console's number of acceptors
+console.acceptors.cui = 3
+console.acceptors.json = 16
+
+
+## --------------------------------------------------------------------
+## MANAGER - System
+##     * Only set its configurations to **Manager-master**
+## --------------------------------------------------------------------
+## DC Id
+system.dc_id = dc_1
+
+## Cluster Id
+system.cluster_id = leofs_1
+
+## --------------------------------------------------------------------
+## MANAGER - Consistency Level
+##     * Only set its configurations to **Manager-master**
+##     * See: https://leo-project.net/leofs/docs/configuration/configuration_1.html
+## --------------------------------------------------------------------
+## A number of replicas
+consistency.num_of_replicas = 3
+
+## A number of replicas needed for a successful WRITE operation
+consistency.write = 2
+
+## A number of replicas needed for a successful READ operation
+consistency.read = 1
+
+## A number of replicas needed for a successful DELETE operation
+consistency.delete = 2
+
+## A number of rack-aware replicas
+consistency.rack_aware_replicas = 2
+
+
+## --------------------------------------------------------------------
+## MANAGER - Multi DataCenter Settings
+## --------------------------------------------------------------------
+## A number of replication targets
+mdc_replication.max_targets = 2
+
+## A number of replicas a DC
+mdc_replication.num_of_replicas_a_dc = 1
+
+
+## --------------------------------------------------------------------
+## MANAGER - Mnesia
+##     * Store the info storage-cluster and the info of gateway(s)
+##     * Store the RING and the command histories
+## --------------------------------------------------------------------
+## Mnesia dir
+mnesia.dir = ./work/mnesia/127.0.0.1
+
+## The write threshold for transaction log dumps
+## as the number of writes to the transaction log
+mnesia.dump_log_write_threshold = 50000
+
+## Controls how often disc_copies tables are dumped from memory
+mnesia.dc_dump_limit = 40
+
+
+## --------------------------------------------------------------------
+## MANAGER - Log
+## --------------------------------------------------------------------
+## Log level: [0:debug, 1:info, 2:warn, 3:error]
+## log.log_level = 1
+
+## Output log file(s) - Erlang's log
+## log.erlang = ./log/erlang
+
+## Output log file(s) - app
+## log.app = ./log/app
+
+## Output log file(s) - members of storage-cluster
+## log.member_dir = ./log/ring
+
+## Output log file(s) - ring
+## log.ring_dir = ./log/ring
+
+
+## --------------------------------------------------------------------
+## MANAGER - Other Directories
+## --------------------------------------------------------------------
+## Directory of queue for monitoring "RING"
+## queue_dir = ./work/queue
+
+## Directory of SNMP agent configuration
+## snmp_agent = ./snmp/snmpa_manager_0/LEO-MANAGER
+
+
+## --------------------------------------------------------------------
+## RPC
+## --------------------------------------------------------------------
+## RPC-Server's acceptors
+rpc.server.acceptors = 64
+
+## RPC-Server's listening port number
+rpc.server.listen_port = 13075
+
+## RPC-Server's listening timeout
+rpc.server.listen_timeout = 5000
+
+
+## --------------------------------------------------------------------
+## Other Libs
+## --------------------------------------------------------------------
+## Enable profiler - leo_backend_db
+## leo_backend_db.profile = false
+
+## Enable profiler - leo_logger
+## leo_logger.profile = false
+
+## Enable profiler - leo_mq
+## leo_mq.profile = false
+
+## Enable profiler - leo_redundant_manager
+## leo_redundant_manager.profile = false
+
+## Enable profiler - leo_statistics
+## leo_statistics.profile = false
+
+
+#======================================================================
+# For vm.args
+#======================================================================
+## Name of the leofs-gateway node
+nodename = manager_0@127.0.0.1
+
+## Cookie for distributed node communication.  All nodes in the same cluster
+## should use the same cookie or they will not be able to communicate.
+distributed_cookie = 401321b4
+
+## Enable kernel poll
+erlang.kernel_poll = true
+
+## Number of async threads
+erlang.asyc_threads = 32
+
+## Increase number of concurrent ports/sockets
+erlang.max_ports = 64000
+
+## Set the location of crash dumps
+erlang.crash_dump = ./log/erl_crash.dump
+
+## Raise the ETS table limit
+erlang.max_ets_tables = 256000
+
+## Raise the default erlang process limit
+process_limit = 1048576
+
+## Path of SNMP-agent configuration
+##snmp_conf = ./snmp/snmpa_manager_0/leo_manager_snmp

--- a/priv/test/rack-awareness-test/app-m1.conf
+++ b/priv/test/rack-awareness-test/app-m1.conf
@@ -1,0 +1,154 @@
+#======================================================================
+# LeoFS - Manager Configuration (SLAVE)
+#======================================================================
+## --------------------------------------------------------------------
+## SASL
+## --------------------------------------------------------------------
+## See: http://www.erlang.org/doc/man/sasl_app.html
+##
+## The following configuration parameters are defined for
+## the SASL application. See app(4) for more information
+## about configuration parameters
+
+## SASL error log path
+## sasl.sasl_error_log = ./log/sasl/sasl-error.log
+
+## Restricts the error logging performed by the specified sasl_error_logger
+## to error reports, progress reports, or both.
+## errlog_type = [error | progress | all]
+## sasl.errlog_type = error
+
+## Specifies in which directory the files are stored.
+## If this parameter is undefined or false, the error_logger_mf_h is not installed.
+# sasl.error_logger_mf_dir = ./log/sasl
+
+## Specifies how large each individual file can be.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxbytes = 10485760
+
+## Specifies how many files are used.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxfiles = 5
+
+## --------------------------------------------------------------------
+## MANAGER
+## --------------------------------------------------------------------
+## Partner of manager's alias
+manager.partner = manager_0@127.0.0.1
+
+## Manager-console accepatable port number
+console.port.cui  = 10011
+console.port.json = 10021
+
+## Manager-console's number of acceptors
+console.acceptors.cui = 3
+console.acceptors.json = 16
+
+
+## --------------------------------------------------------------------
+## MANAGER - Mnesia
+##     * Store the info storage-cluster and the info of gateway(s)
+##     * Store the RING and the command histories
+## --------------------------------------------------------------------
+## Mnesia dir
+mnesia.dir = ./work/mnesia/127.0.0.1
+
+## The write threshold for transaction log dumps
+## as the number of writes to the transaction log
+mnesia.dump_log_write_threshold = 50000
+
+## Controls how often disc_copies tables are dumped from memory
+mnesia.dc_dump_limit = 40
+
+
+## --------------------------------------------------------------------
+## MANAGER - Log
+## --------------------------------------------------------------------
+## Log level: [0:debug, 1:info, 2:warn, 3:error]
+## log.log_level = 1
+
+## Output log file(s) - Erlang's log
+## log.erlang = ./log/erlang
+
+## Output log file(s) - app
+## log.app = ./log/app
+
+## Output log file(s) - members of storage-cluster
+## log.member_dir = ./log/ring
+
+## Output log file(s) - ring
+## log.ring_dir = ./log/ring
+
+
+## --------------------------------------------------------------------
+## MANAGER - Other Directories
+## --------------------------------------------------------------------
+## Directory of queue for monitoring "RING"
+## queue_dir = ./work/queue
+
+## Directory of SNMP agent configuration
+snmp_agent = ./snmp/snmpa_manager_1/LEO-MANAGER
+
+
+## --------------------------------------------------------------------
+## RPC
+## --------------------------------------------------------------------
+## RPC-Server's acceptors
+rpc.server.acceptors = 64
+
+## RPC-Server's listening port number
+rpc.server.listen_port = 13076
+
+## RPC-Server's listening timeout
+rpc.server.listen_timeout = 5000
+
+
+## --------------------------------------------------------------------
+## Other Libs
+## --------------------------------------------------------------------
+## Enable profiler - leo_backend_db
+## leo_backend_db.profile = false
+
+## Enable profiler - leo_logger
+## leo_logger.profile = false
+
+## Enable profiler - leo_mq
+## leo_mq.profile = false
+
+## Enable profiler - leo_redundant_manager
+## leo_redundant_manager.profile = false
+
+## Enable profiler - leo_statistics
+## leo_statistics.profile = false
+
+
+#======================================================================
+# For vm.args
+#======================================================================
+## Name of the leofs-gateway node
+nodename = manager_1@127.0.0.1
+
+## Cookie for distributed node communication.  All nodes in the same cluster
+## should use the same cookie or they will not be able to communicate.
+distributed_cookie = 401321b4
+
+## Enable kernel poll
+erlang.kernel_poll = true
+
+## Number of async threads
+erlang.asyc_threads = 32
+
+## Increase number of concurrent ports/sockets
+erlang.max_ports = 64000
+
+## Set the location of crash dumps
+erlang.crash_dump = ./log/erl_crash.dump
+
+## Raise the ETS table limit
+erlang.max_ets_tables = 256000
+
+## Raise the default erlang process limit
+process_limit = 1048576
+
+## Path of SNMP-agent configuration
+snmp_conf = ./snmp/snmpa_manager_1/leo_manager_snmp

--- a/priv/test/rack-awareness-test/app-s0.conf
+++ b/priv/test/rack-awareness-test/app-s0.conf
@@ -1,0 +1,426 @@
+##======================================================================
+## LeoFS - Storage Configuration
+##
+## See: http://leo-project.net/leofs/docs/configuration/configuration_2.html
+##======================================================================
+## --------------------------------------------------------------------
+## SASL
+## --------------------------------------------------------------------
+## See: http://www.erlang.org/doc/man/sasl_app.html
+##
+## The following configuration parameters are defined for
+## the SASL application. See app(4) for more information
+## about configuration parameters
+
+## SASL error log path
+## sasl.sasl_error_log = ./log/sasl/sasl-error.log
+
+## Restricts the error logging performed by the specified sasl_error_logger
+## to error reports, progress reports, or both.
+## errlog_type = [error | progress | all]
+## sasl.errlog_type = error
+
+## Specifies in which directory the files are stored.
+## If this parameter is undefined or false, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_dir = ./log/sasl
+
+## Specifies how large each individual file can be.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxbytes = 10485760
+
+## Specifies how many files are used.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxfiles = 5
+
+## --------------------------------------------------------------------
+## Manager's Node(s)
+## --------------------------------------------------------------------
+## Name of Manager node(s)
+managers = [manager_0@127.0.0.1, manager_1@127.0.0.1]
+
+## --------------------------------------------------------------------
+## STORAGE
+## --------------------------------------------------------------------
+## Object container
+obj_containers.path = [./avs]
+obj_containers.num_of_containers = [8]
+
+## e.g. Case of plural pathes
+## obj_containers.path = [/var/leofs/avs/1, /var/leofs/avs/2]
+## obj_containers.num_of_containers = [32, 64]
+
+## Metadata Storage: [bitcask, leveldb] - default:leveldb
+## obj_containers.metadata_storage = leveldb
+
+## A number of virtual-nodes for the redundant-manager
+## num_of_vnodes = 168
+
+## Enable strict check between checksum of a metadata and checksum of an object
+## - default:false
+## object_storage.is_strict_check = false
+
+## Threshold of slow processing (msec) - default:1000(msec)
+## object_storage.threshold_of_slow_processing = 1000
+
+## Timeout of seeking metadatas per a metadata - default:10(msec)
+## seeking_timeout_per_metadata = 10
+
+## Maximum number of processes for both write and read operation
+## since v1.2.20
+max_num_of_procs = 3000
+
+## Total number of obj-storage-read processes per object-container, AVS
+## Range: [1..100]
+## since v1.2.20
+num_of_obj_storage_read_procs = 3
+
+
+## --------------------------------------------------------------------
+## STORAGE - Watchdog
+## --------------------------------------------------------------------
+## When reach a number of safe (clear watchdog), a watchdog loosen the control
+watchdog.common.loosen_control_at_safe_count = 1
+
+##
+##  Watchdog.REX(RPC)
+##
+## Is rex-watchdog enabled - default:false
+watchdog.rex.is_enabled = true
+
+## rex - watch interval - default:5sec
+watchdog.rex.interval = 10
+
+## Threshold memory capacity of binary for rex(rpc) - default:32MB
+watchdog.rex.threshold_mem_capacity = 33554432
+
+
+##
+##  Watchdog.CPU
+##
+## Is cpu-watchdog enabled - default:false
+watchdog.cpu.is_enabled = false
+
+## cpu - raised error times
+watchdog.cpu.raised_error_times = 5
+
+## cpu - watch interval - default:5sec
+watchdog.cpu.interval = 10
+
+## Threshold CPU load avg for 1min/5min - default:5.0
+watchdog.cpu.threshold_cpu_load_avg = 5.0
+
+## Threshold CPU load util - default:100 = "100%"
+watchdog.cpu.threshold_cpu_util = 100
+
+##
+##  Watchdog.DISK
+##
+## Is disk-watchdog enabled - default:false
+watchdog.disk.is_enabled = false
+
+## disk - raised error times
+watchdog.disk.raised_error_times = 5
+
+## disk - watch interval - default:1sec
+watchdog.disk.interval = 10
+
+## Threshold use(%) of a target disk's capacity - defalut:85%
+watchdog.disk.threshold_disk_use = 85
+
+## Threshold disk utilization(%) - defalut:90%
+watchdog.disk.threshold_disk_util = 90
+
+## Threshold disk read kb/sec - defalut:98304(KB) = 96MB
+watchdog.disk.threshold_disk_rkb = 98304
+
+## Threshold disk write kb/sec - defalut:98304(KB) = 96MB
+watchdog.disk.threshold_disk_wkb = 98304
+
+## disk target devices for checking disk utilization
+## watchdog.disk.target_devices = []
+
+##
+##  Watchdog.Cluster
+##
+## Is cluster-watchdog enabled - default:false
+watchdog.cluster.is_enabled = false
+
+## cluster - watch interval - default:10sec
+watchdog.cluster.interval = 10
+
+##
+##  Watchdog.Error
+##
+## Is error-watchdog enabled - default:false
+watchdog.error.is_enabled = false
+
+## error - watch interval - default:60sec
+watchdog.error.interval = 60
+
+## error - threshold error count - default:100
+watchdog.error.threshold_count = 100
+
+
+## --------------------------------------------------------------------
+## STORAGE - Autonomic Operation
+## --------------------------------------------------------------------
+## [compaction] enabled compaction? - default:false
+autonomic_op.compaction.is_enabled = false
+
+## [compaction] number of parallel procs - default:1
+autonomic_op.compaction.parallel_procs = 1
+
+## [compaction] execution intarval time(sec) - default:3600(sec) (60min)
+autonomic_op.compaction.interval = 3600
+
+## [compaction] warning ratio of active size - default:70%
+autonomic_op.compaction.warn_active_size_ratio = 70
+
+## [compaction] threshold ratio of active size - default:60%
+autonomic_op.compaction.threshold_active_size_ratio = 60
+
+
+## --------------------------------------------------------------------
+## STORAGE - Data Compcation
+## --------------------------------------------------------------------
+## Limit of a number of procs to execute data-compaction in parallel
+compaction.limit_num_of_compaction_procs = 4
+
+## Regular value of compaction-proc waiting time/batch-proc(msec)
+compaction.waiting_time_regular = 500
+
+## Maximum value of compaction-proc waiting time/batch-proc(msec)
+compaction.waiting_time_max = 3000
+
+
+## Regular compaction batch processes
+compaction.batch_procs_regular = 1000
+
+## Maximum compaction batch processes
+compaction.batch_procs_max = 1500
+
+
+## --------------------------------------------------------------------
+## STORAGE - MQ
+## --------------------------------------------------------------------
+## MQ backend storage: [bitcask] - default:bitcask
+mq.backend_db = leveldb
+
+## A number of mq-server's processes
+mq.num_of_mq_procs = 8
+
+##
+## [Number of bach processes of message]
+##
+## Maximum number of bach processes of message
+mq.num_of_batch_process_max = 3000
+
+## Regular value of bach processes of message
+mq.num_of_batch_process_regular = 1600
+
+##
+## [Interval beween batch-procs]
+##
+## Maximum value of interval between batch-procs(msec)
+mq.interval_between_batch_procs_max = 3000
+
+## Regular value of interval between batch-procs(msec)
+mq.interval_between_batch_procs_regular = 500
+
+
+## --------------------------------------------------------------------
+## STORAGE - Replication/Recovery object(s)
+## --------------------------------------------------------------------
+## Rack-id for the rack-awareness replica placement
+replication.rack_awareness.rack_id = rack_1
+
+## Size of stacked objects (bytes)
+## replication.recovery.size_of_stacked_objs = 33554432
+
+## Stacking timeout (sec)
+## replication.recovery.stacking_timeout = 5
+
+
+## --------------------------------------------------------------------
+## STORAGE - MDC Replication
+## --------------------------------------------------------------------
+## Size of stacked objects (bytes) - default:32MB
+mdc_replication.size_of_stacked_objs = 33554432
+
+## Stacking timeout (sec)
+mdc_replication.stacking_timeout = 30
+
+## Request timeout (msec)
+mdc_replication.req_timeout = 30000
+
+## Number of stacking procs
+mdc_replication.stacking_procs = 1
+
+
+## --------------------------------------------------------------------
+## STORAGE - Log
+## --------------------------------------------------------------------
+## Log level: [0:debug, 1:info, 2:warn, 3:error]
+log.log_level = 1
+
+## Is enable access-log [true, false]
+log.is_enable_access_log = true
+
+## Access log's level
+##   - 0: only regular case
+##   - 1: includes error cases
+log.access_log_level = 0
+
+## Output log file(s) - Erlang's log
+## log.erlang = ./log/erlang
+
+## Output log file(s) - app
+## log.app = ./log/app
+
+## Output log file(s) - members of storage-cluster
+## log.member_dir = ./log/ring
+
+## Output log file(s) - ring
+## log.ring_dir = ./log/ring
+
+## Output data-diagnosis log
+log.is_enable_diagnosis_log = true
+
+## --------------------------------------------------------------------
+## STORAGE - Other Directories
+## --------------------------------------------------------------------
+## Directory of queue for monitoring "RING"
+## queue_dir  = ./work/queue
+
+## Directory of SNMP agent configuration
+snmp_agent = ./snmp/snmpa_storage_0/LEO-STORAGE
+
+
+## --------------------------------------------------------------------
+## Other Libs
+## --------------------------------------------------------------------
+## Send after interval
+## leo_ordning_reda.send_after_interval = 100
+
+## Temporary directory of stacked objects
+## leo_ordning_reda.temp_stacked_dir = "work/ord_reda/"
+
+
+## --------------------------------------------------------------------
+## RPC
+## --------------------------------------------------------------------
+## RPC-Server's acceptors
+## this value must be determinted by following logic
+## rpc.server.acceptor need to be larger than
+## rpc.client.connection_pool(buffer)_size * "# of storage nodes + # of manager nodes in your cluster"
+## The default value is suitable for less than 16 nodes in a cluster
+## rpc.server.acceptors = 128
+
+## RPC-Server's listening port number
+rpc.server.listen_port = 13077
+
+## RPC-Server's listening timeout
+## rpc.server.listen_timeout = 30000
+
+## RPC-Client's size of connection pool
+## rpc.client.connection_pool_size = 8
+
+## RPC-Client's size of connection buffer
+## rpc.client.connection_buffer_size = 8
+
+## RPC-Client's max number of requests for reconnection to a remote-node
+## * 1..<integer>: specialized value
+## rpc.client.max_requests_for_reconnection = 64
+
+
+## --------------------------------------------------------------------
+## MANAGER - Mnesia
+##     * Store the info storage-cluster and the info of gateway(s)
+##     * Store the RING and the command histories
+## --------------------------------------------------------------------
+## The write threshold for transaction log dumps
+## as the number of writes to the transaction log
+mnesia.dump_log_write_threshold = 50000
+
+## Controls how often disc_copies tables are dumped from memory
+mnesia.dc_dump_limit = 40
+
+## --------------------------------------------------------------------
+## Profiling
+## --------------------------------------------------------------------
+## Enable profiler - leo_backend_db
+## leo_backend_db.profile = false
+
+## Enable profiler - leo_logger
+## leo_logger.profile = false
+
+## Enable profiler - leo_mq
+## leo_mq.profile = false
+
+## Enable profiler - leo_object_storage
+## leo_object_storage.profile = false
+
+## Enable profiler - leo_ordning_reda
+## leo_ordning_reda.profile = false
+
+## Enable profiler - leo_redundant_manager
+## leo_redundant_manager.profile = false
+
+## Enable profiler - leo_rpc
+## leo_rpc.profile = false
+
+## Enable profiler - leo_statistics
+## leo_statistics.profile = false
+
+
+##======================================================================
+## For vm.args
+##======================================================================
+## Name of the leofs-storage node
+nodename = storage_0@127.0.0.1
+
+## Cookie for distributed node communication.  All nodes in the same cluster
+## should use the same cookie or they will not be able to communicate.
+distributed_cookie = 401321b4
+
+## Enable kernel poll
+erlang.kernel_poll = true
+
+## Number of async threads
+erlang.async_threads = 32
+
+## Increase number of concurrent ports/sockets
+erlang.max_ports = 64000
+
+## Set the location of crash dumps
+erlang.crash_dump = ./log/erl_crash.dump
+
+## Raise the ETS table limit
+erlang.max_ets_tables = 256000
+
+## Enable SMP
+erlang.smp = enable
+
+## Erlang scheduler's compaction of load
+erlang.schedulers.compaction_of_load = true
+
+## Erlang scheduler's balancing of load
+erlang.schedulers.utilization_balancing = false
+
+## Sender-side network distribution buffer size
+## - default 32MB (32768KB)
+erlang.distribution_buffer_size = 32768
+
+## A non-negative integer which indicates
+## how many times generational garbage collections
+## can be done without forcing a fullsweep collection
+erlang.fullsweep_after = 0
+
+## Enable/Disable eager check I/O (Erlang 17.4/erts-6.3-, ref:OTP-12117)
+erlang.secio = false
+
+## Raise the default erlang process limit
+process_limit = 1048576
+
+## Path of SNMP-agent configuration
+snmp_conf = ./snmp/snmpa_storage_0/leo_storage_snmp

--- a/priv/test/rack-awareness-test/app-s1.conf
+++ b/priv/test/rack-awareness-test/app-s1.conf
@@ -1,0 +1,423 @@
+##======================================================================
+## LeoFS - Storage Configuration
+##
+## See: http://leo-project.net/leofs/docs/configuration/configuration_2.html
+##======================================================================
+## --------------------------------------------------------------------
+## SASL
+## --------------------------------------------------------------------
+## See: http://www.erlang.org/doc/man/sasl_app.html
+##
+## The following configuration parameters are defined for
+## the SASL application. See app(4) for more information
+## about configuration parameters
+
+## SASL error log path
+## sasl.sasl_error_log = ./log/sasl/sasl-error.log
+
+## Restricts the error logging performed by the specified sasl_error_logger
+## to error reports, progress reports, or both.
+## errlog_type = [error | progress | all]
+## sasl.errlog_type = error
+
+## Specifies in which directory the files are stored.
+## If this parameter is undefined or false, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_dir = ./log/sasl
+
+## Specifies how large each individual file can be.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxbytes = 10485760
+
+## Specifies how many files are used.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxfiles = 5
+
+## --------------------------------------------------------------------
+## Manager's Node(s)
+## --------------------------------------------------------------------
+## Name of Manager node(s)
+managers = [manager_0@127.0.0.1, manager_1@127.0.0.1]
+
+## --------------------------------------------------------------------
+## STORAGE
+## --------------------------------------------------------------------
+## Object container
+obj_containers.path = [./avs]
+obj_containers.num_of_containers = [8]
+
+## e.g. Case of plural pathes
+## obj_containers.path = [/var/leofs/avs/1, /var/leofs/avs/2]
+## obj_containers.num_of_containers = [32, 64]
+
+## Metadata Storage: [bitcask, leveldb] - default:leveldb
+## obj_containers.metadata_storage = leveldb
+
+## A number of virtual-nodes for the redundant-manager
+## num_of_vnodes = 168
+
+## Enable strict check between checksum of a metadata and checksum of an object
+## - default:false
+## object_storage.is_strict_check = false
+
+## Threshold of slow processing (msec) - default:1000(msec)
+## object_storage.threshold_of_slow_processing = 1000
+
+## Maximum number of processes for both write and read operation
+## since v1.2.20
+max_num_of_procs = 3000
+
+## Total number of obj-storage-read processes per object-container, AVS
+## Range: [1..100]
+## since v1.2.20
+num_of_obj_storage_read_procs = 3
+
+
+## --------------------------------------------------------------------
+## STORAGE - Watchdog
+## --------------------------------------------------------------------
+## When reach a number of safe (clear watchdog), a watchdog loosen the control
+watchdog.common.loosen_control_at_safe_count = 1
+
+##
+##  Watchdog.REX(RPC)
+##
+## Is rex-watchdog enabled - default:false
+watchdog.rex.is_enabled = true
+
+## rex - watch interval - default:5sec
+watchdog.rex.interval = 10
+
+## Threshold memory capacity of binary for rex(rpc) - default:32MB
+watchdog.rex.threshold_mem_capacity = 33554432
+
+
+##
+##  Watchdog.CPU
+##
+## Is cpu-watchdog enabled - default:false
+watchdog.cpu.is_enabled = false
+
+## cpu - raised error times
+watchdog.cpu.raised_error_times = 5
+
+## cpu - watch interval - default:5sec
+watchdog.cpu.interval = 10
+
+## Threshold CPU load avg for 1min/5min - default:5.0
+watchdog.cpu.threshold_cpu_load_avg = 5.0
+
+## Threshold CPU load util - default:100 = "100%"
+watchdog.cpu.threshold_cpu_util = 100
+
+##
+##  Watchdog.DISK
+##
+## Is disk-watchdog enabled - default:false
+watchdog.disk.is_enabled = false
+
+## disk - raised error times
+watchdog.disk.raised_error_times = 5
+
+## disk - watch interval - default:1sec
+watchdog.disk.interval = 10
+
+## Threshold use(%) of a target disk's capacity - defalut:85%
+watchdog.disk.threshold_disk_use = 85
+
+## Threshold disk utilization(%) - defalut:90%
+watchdog.disk.threshold_disk_util = 90
+
+## Threshold disk read kb/sec - defalut:98304(KB) = 96MB
+watchdog.disk.threshold_disk_rkb = 98304
+
+## Threshold disk write kb/sec - defalut:98304(KB) = 96MB
+watchdog.disk.threshold_disk_wkb = 98304
+
+## disk target devices for checking disk utilization
+## watchdog.disk.target_devices = []
+
+##
+##  Watchdog.Cluster
+##
+## Is cluster-watchdog enabled - default:false
+watchdog.cluster.is_enabled = false
+
+## cluster - watch interval - default:10sec
+watchdog.cluster.interval = 10
+
+##
+##  Watchdog.Error
+##
+## Is error-watchdog enabled - default:false
+watchdog.error.is_enabled = false
+
+## error - watch interval - default:60sec
+watchdog.error.interval = 60
+
+## error - threshold error count - default:100
+watchdog.error.threshold_count = 100
+
+
+## --------------------------------------------------------------------
+## STORAGE - Autonomic Operation
+## --------------------------------------------------------------------
+## [compaction] enabled compaction? - default:false
+autonomic_op.compaction.is_enabled = false
+
+## [compaction] number of parallel procs - default:1
+autonomic_op.compaction.parallel_procs = 1
+
+## [compaction] execution intarval time(sec) - default:3600(sec) (60min)
+autonomic_op.compaction.interval = 3600
+
+## [compaction] warning ratio of active size - default:70%
+autonomic_op.compaction.warn_active_size_ratio = 70
+
+## [compaction] threshold ratio of active size - default:60%
+autonomic_op.compaction.threshold_active_size_ratio = 60
+
+
+## --------------------------------------------------------------------
+## STORAGE - Data Compcation
+## --------------------------------------------------------------------
+## Limit of a number of procs to execute data-compaction in parallel
+compaction.limit_num_of_compaction_procs = 4
+
+## Regular value of compaction-proc waiting time/batch-proc(msec)
+compaction.waiting_time_regular = 500
+
+## Maximum value of compaction-proc waiting time/batch-proc(msec)
+compaction.waiting_time_max = 3000
+
+
+## Regular compaction batch processes
+compaction.batch_procs_regular = 1000
+
+## Maximum compaction batch processes
+compaction.batch_procs_max = 1500
+
+
+## --------------------------------------------------------------------
+## STORAGE - MQ
+## --------------------------------------------------------------------
+## MQ backend storage: [bitcask] - default:bitcask
+mq.backend_db = leveldb
+
+## A number of mq-server's processes
+mq.num_of_mq_procs = 8
+
+##
+## [Number of bach processes of message]
+##
+## Maximum number of bach processes of message
+mq.num_of_batch_process_max = 3000
+
+## Regular value of bach processes of message
+mq.num_of_batch_process_regular = 1600
+
+##
+## [Interval beween batch-procs]
+##
+## Maximum value of interval between batch-procs(msec)
+mq.interval_between_batch_procs_max = 3000
+
+## Regular value of interval between batch-procs(msec)
+mq.interval_between_batch_procs_regular = 500
+
+
+## --------------------------------------------------------------------
+## STORAGE - Replication/Recovery object(s)
+## --------------------------------------------------------------------
+## Rack-id for the rack-awareness replica placement
+replication.rack_awareness.rack_id = rack_1
+
+## Size of stacked objects (bytes)
+## replication.recovery.size_of_stacked_objs = 33554432
+
+## Stacking timeout (sec)
+## replication.recovery.stacking_timeout = 5
+
+
+## --------------------------------------------------------------------
+## STORAGE - MDC Replication
+## --------------------------------------------------------------------
+## Size of stacked objects (bytes) - default:32MB
+mdc_replication.size_of_stacked_objs = 33554432
+
+## Stacking timeout (sec)
+mdc_replication.stacking_timeout = 30
+
+## Request timeout (msec)
+mdc_replication.req_timeout = 30000
+
+## Number of stacking procs
+mdc_replication.stacking_procs = 1
+
+
+## --------------------------------------------------------------------
+## STORAGE - Log
+## --------------------------------------------------------------------
+## Log level: [0:debug, 1:info, 2:warn, 3:error]
+log.log_level = 1
+
+## Is enable access-log [true, false]
+log.is_enable_access_log = true
+
+## Access log's level
+##   - 0: only regular case
+##   - 1: includes error cases
+log.access_log_level = 0
+
+## Output log file(s) - Erlang's log
+## log.erlang = ./log/erlang
+
+## Output log file(s) - app
+## log.app = ./log/app
+
+## Output log file(s) - members of storage-cluster
+## log.member_dir = ./log/ring
+
+## Output log file(s) - ring
+## log.ring_dir = ./log/ring
+
+## Output data-diagnosis log
+log.is_enable_diagnosis_log = true
+
+## --------------------------------------------------------------------
+## STORAGE - Other Directories
+## --------------------------------------------------------------------
+## Directory of queue for monitoring "RING"
+## queue_dir  = ./work/queue
+
+## Directory of SNMP agent configuration
+snmp_agent = ./snmp/snmpa_storage_1/LEO-STORAGE
+
+
+## --------------------------------------------------------------------
+## Other Libs
+## --------------------------------------------------------------------
+## Send after interval
+## leo_ordning_reda.send_after_interval = 100
+
+## Temporary directory of stacked objects
+## leo_ordning_reda.temp_stacked_dir = "work/ord_reda/"
+
+
+## --------------------------------------------------------------------
+## RPC
+## --------------------------------------------------------------------
+## RPC-Server's acceptors
+## this value must be determinted by following logic
+## rpc.server.acceptor need to be larger than
+## rpc.client.connection_pool(buffer)_size * "# of storage nodes + # of manager nodes in your cluster"
+## The default value is suitable for less than 16 nodes in a cluster
+## rpc.server.acceptors = 128
+
+## RPC-Server's listening port number
+rpc.server.listen_port = 13078
+
+## RPC-Server's listening timeout
+## rpc.server.listen_timeout = 30000
+
+## RPC-Client's size of connection pool
+## rpc.client.connection_pool_size = 8
+
+## RPC-Client's size of connection buffer
+## rpc.client.connection_buffer_size = 8
+
+## RPC-Client's max number of requests for reconnection to a remote-node
+## * 1..<integer>: specialized value
+## rpc.client.max_requests_for_reconnection = 64
+
+
+## --------------------------------------------------------------------
+## MANAGER - Mnesia
+##     * Store the info storage-cluster and the info of gateway(s)
+##     * Store the RING and the command histories
+## --------------------------------------------------------------------
+## The write threshold for transaction log dumps
+## as the number of writes to the transaction log
+mnesia.dump_log_write_threshold = 50000
+
+## Controls how often disc_copies tables are dumped from memory
+mnesia.dc_dump_limit = 40
+
+## --------------------------------------------------------------------
+## Profiling
+## --------------------------------------------------------------------
+## Enable profiler - leo_backend_db
+## leo_backend_db.profile = false
+
+## Enable profiler - leo_logger
+## leo_logger.profile = false
+
+## Enable profiler - leo_mq
+## leo_mq.profile = false
+
+## Enable profiler - leo_object_storage
+## leo_object_storage.profile = false
+
+## Enable profiler - leo_ordning_reda
+## leo_ordning_reda.profile = false
+
+## Enable profiler - leo_redundant_manager
+## leo_redundant_manager.profile = false
+
+## Enable profiler - leo_rpc
+## leo_rpc.profile = false
+
+## Enable profiler - leo_statistics
+## leo_statistics.profile = false
+
+
+##======================================================================
+## For vm.args
+##======================================================================
+## Name of the leofs-storage node
+nodename = storage_1@127.0.0.1
+
+## Cookie for distributed node communication.  All nodes in the same cluster
+## should use the same cookie or they will not be able to communicate.
+distributed_cookie = 401321b4
+
+## Enable kernel poll
+erlang.kernel_poll = true
+
+## Number of async threads
+erlang.async_threads = 32
+
+## Increase number of concurrent ports/sockets
+erlang.max_ports = 64000
+
+## Set the location of crash dumps
+erlang.crash_dump = ./log/erl_crash.dump
+
+## Raise the ETS table limit
+erlang.max_ets_tables = 256000
+
+## Enable SMP
+erlang.smp = enable
+
+## Erlang scheduler's compaction of load
+erlang.schedulers.compaction_of_load = true
+
+## Erlang scheduler's balancing of load
+erlang.schedulers.utilization_balancing = false
+
+## Sender-side network distribution buffer size
+## - default 32MB (32768KB)
+erlang.distribution_buffer_size = 32768
+
+## A non-negative integer which indicates
+## how many times generational garbage collections
+## can be done without forcing a fullsweep collection
+erlang.fullsweep_after = 0
+
+## Enable/Disable eager check I/O (Erlang 17.4/erts-6.3-, ref:OTP-12117)
+erlang.secio = false
+
+## Raise the default erlang process limit
+process_limit = 1048576
+
+## Path of SNMP-agent configuration
+snmp_conf = ./snmp/snmpa_storage_1/leo_storage_snmp

--- a/priv/test/rack-awareness-test/app-s2.conf
+++ b/priv/test/rack-awareness-test/app-s2.conf
@@ -1,0 +1,423 @@
+##======================================================================
+## LeoFS - Storage Configuration
+##
+## See: http://leo-project.net/leofs/docs/configuration/configuration_2.html
+##======================================================================
+## --------------------------------------------------------------------
+## SASL
+## --------------------------------------------------------------------
+## See: http://www.erlang.org/doc/man/sasl_app.html
+##
+## The following configuration parameters are defined for
+## the SASL application. See app(4) for more information
+## about configuration parameters
+
+## SASL error log path
+## sasl.sasl_error_log = ./log/sasl/sasl-error.log
+
+## Restricts the error logging performed by the specified sasl_error_logger
+## to error reports, progress reports, or both.
+## errlog_type = [error | progress | all]
+## sasl.errlog_type = error
+
+## Specifies in which directory the files are stored.
+## If this parameter is undefined or false, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_dir = ./log/sasl
+
+## Specifies how large each individual file can be.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxbytes = 10485760
+
+## Specifies how many files are used.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxfiles = 5
+
+## --------------------------------------------------------------------
+## Manager's Node(s)
+## --------------------------------------------------------------------
+## Name of Manager node(s)
+managers = [manager_0@127.0.0.1, manager_1@127.0.0.1]
+
+## --------------------------------------------------------------------
+## STORAGE
+## --------------------------------------------------------------------
+## Object container
+obj_containers.path = [./avs]
+obj_containers.num_of_containers = [8]
+
+## e.g. Case of plural pathes
+## obj_containers.path = [/var/leofs/avs/1, /var/leofs/avs/2]
+## obj_containers.num_of_containers = [32, 64]
+
+## Metadata Storage: [bitcask, leveldb] - default:leveldb
+## obj_containers.metadata_storage = leveldb
+
+## A number of virtual-nodes for the redundant-manager
+## num_of_vnodes = 168
+
+## Enable strict check between checksum of a metadata and checksum of an object
+## - default:false
+## object_storage.is_strict_check = false
+
+## Threshold of slow processing (msec) - default:1000(msec)
+## object_storage.threshold_of_slow_processing = 1000
+
+## Maximum number of processes for both write and read operation
+## since v1.2.20
+max_num_of_procs = 3000
+
+## Total number of obj-storage-read processes per object-container, AVS
+## Range: [1..100]
+## since v1.2.20
+num_of_obj_storage_read_procs = 3
+
+
+## --------------------------------------------------------------------
+## STORAGE - Watchdog
+## --------------------------------------------------------------------
+## When reach a number of safe (clear watchdog), a watchdog loosen the control
+watchdog.common.loosen_control_at_safe_count = 1
+
+##
+##  Watchdog.REX(RPC)
+##
+## Is rex-watchdog enabled - default:false
+watchdog.rex.is_enabled = true
+
+## rex - watch interval - default:5sec
+watchdog.rex.interval = 10
+
+## Threshold memory capacity of binary for rex(rpc) - default:32MB
+watchdog.rex.threshold_mem_capacity = 33554432
+
+
+##
+##  Watchdog.CPU
+##
+## Is cpu-watchdog enabled - default:false
+watchdog.cpu.is_enabled = false
+
+## cpu - raised error times
+watchdog.cpu.raised_error_times = 5
+
+## cpu - watch interval - default:5sec
+watchdog.cpu.interval = 10
+
+## Threshold CPU load avg for 1min/5min - default:5.0
+watchdog.cpu.threshold_cpu_load_avg = 5.0
+
+## Threshold CPU load util - default:100 = "100%"
+watchdog.cpu.threshold_cpu_util = 100
+
+##
+##  Watchdog.DISK
+##
+## Is disk-watchdog enabled - default:false
+watchdog.disk.is_enabled = false
+
+## disk - raised error times
+watchdog.disk.raised_error_times = 5
+
+## disk - watch interval - default:1sec
+watchdog.disk.interval = 10
+
+## Threshold use(%) of a target disk's capacity - defalut:85%
+watchdog.disk.threshold_disk_use = 85
+
+## Threshold disk utilization(%) - defalut:90%
+watchdog.disk.threshold_disk_util = 90
+
+## Threshold disk read kb/sec - defalut:98304(KB) = 96MB
+watchdog.disk.threshold_disk_rkb = 98304
+
+## Threshold disk write kb/sec - defalut:98304(KB) = 96MB
+watchdog.disk.threshold_disk_wkb = 98304
+
+## disk target devices for checking disk utilization
+## watchdog.disk.target_devices = []
+
+##
+##  Watchdog.Cluster
+##
+## Is cluster-watchdog enabled - default:false
+watchdog.cluster.is_enabled = false
+
+## cluster - watch interval - default:10sec
+watchdog.cluster.interval = 10
+
+##
+##  Watchdog.Error
+##
+## Is error-watchdog enabled - default:false
+watchdog.error.is_enabled = false
+
+## error - watch interval - default:60sec
+watchdog.error.interval = 60
+
+## error - threshold error count - default:100
+watchdog.error.threshold_count = 100
+
+
+## --------------------------------------------------------------------
+## STORAGE - Autonomic Operation
+## --------------------------------------------------------------------
+## [compaction] enabled compaction? - default:false
+autonomic_op.compaction.is_enabled = false
+
+## [compaction] number of parallel procs - default:1
+autonomic_op.compaction.parallel_procs = 1
+
+## [compaction] execution intarval time(sec) - default:3600(sec) (60min)
+autonomic_op.compaction.interval = 3600
+
+## [compaction] warning ratio of active size - default:70%
+autonomic_op.compaction.warn_active_size_ratio = 70
+
+## [compaction] threshold ratio of active size - default:60%
+autonomic_op.compaction.threshold_active_size_ratio = 60
+
+
+## --------------------------------------------------------------------
+## STORAGE - Data Compcation
+## --------------------------------------------------------------------
+## Limit of a number of procs to execute data-compaction in parallel
+compaction.limit_num_of_compaction_procs = 4
+
+## Regular value of compaction-proc waiting time/batch-proc(msec)
+compaction.waiting_time_regular = 500
+
+## Maximum value of compaction-proc waiting time/batch-proc(msec)
+compaction.waiting_time_max = 3000
+
+
+## Regular compaction batch processes
+compaction.batch_procs_regular = 1000
+
+## Maximum compaction batch processes
+compaction.batch_procs_max = 1500
+
+
+## --------------------------------------------------------------------
+## STORAGE - MQ
+## --------------------------------------------------------------------
+## MQ backend storage: [bitcask] - default:bitcask
+mq.backend_db = leveldb
+
+## A number of mq-server's processes
+mq.num_of_mq_procs = 8
+
+##
+## [Number of bach processes of message]
+##
+## Maximum number of bach processes of message
+mq.num_of_batch_process_max = 3000
+
+## Regular value of bach processes of message
+mq.num_of_batch_process_regular = 1600
+
+##
+## [Interval beween batch-procs]
+##
+## Maximum value of interval between batch-procs(msec)
+mq.interval_between_batch_procs_max = 3000
+
+## Regular value of interval between batch-procs(msec)
+mq.interval_between_batch_procs_regular = 500
+
+
+## --------------------------------------------------------------------
+## STORAGE - Replication/Recovery object(s)
+## --------------------------------------------------------------------
+## Rack-id for the rack-awareness replica placement
+replication.rack_awareness.rack_id = rack_2
+
+## Size of stacked objects (bytes)
+## replication.recovery.size_of_stacked_objs = 33554432
+
+## Stacking timeout (sec)
+## replication.recovery.stacking_timeout = 5
+
+
+## --------------------------------------------------------------------
+## STORAGE - MDC Replication
+## --------------------------------------------------------------------
+## Size of stacked objects (bytes) - default:32MB
+mdc_replication.size_of_stacked_objs = 33554432
+
+## Stacking timeout (sec)
+mdc_replication.stacking_timeout = 30
+
+## Request timeout (msec)
+mdc_replication.req_timeout = 30000
+
+## Number of stacking procs
+mdc_replication.stacking_procs = 1
+
+
+## --------------------------------------------------------------------
+## STORAGE - Log
+## --------------------------------------------------------------------
+## Log level: [0:debug, 1:info, 2:warn, 3:error]
+log.log_level = 1
+
+## Is enable access-log [true, false]
+log.is_enable_access_log = true
+
+## Access log's level
+##   - 0: only regular case
+##   - 1: includes error cases
+log.access_log_level = 0
+
+## Output log file(s) - Erlang's log
+## log.erlang = ./log/erlang
+
+## Output log file(s) - app
+## log.app = ./log/app
+
+## Output log file(s) - members of storage-cluster
+## log.member_dir = ./log/ring
+
+## Output log file(s) - ring
+## log.ring_dir = ./log/ring
+
+## Output data-diagnosis log
+log.is_enable_diagnosis_log = true
+
+## --------------------------------------------------------------------
+## STORAGE - Other Directories
+## --------------------------------------------------------------------
+## Directory of queue for monitoring "RING"
+## queue_dir  = ./work/queue
+
+## Directory of SNMP agent configuration
+snmp_agent = ./snmp/snmpa_storage_2/LEO-STORAGE
+
+
+## --------------------------------------------------------------------
+## Other Libs
+## --------------------------------------------------------------------
+## Send after interval
+## leo_ordning_reda.send_after_interval = 100
+
+## Temporary directory of stacked objects
+## leo_ordning_reda.temp_stacked_dir = "work/ord_reda/"
+
+
+## --------------------------------------------------------------------
+## RPC
+## --------------------------------------------------------------------
+## RPC-Server's acceptors
+## this value must be determinted by following logic
+## rpc.server.acceptor need to be larger than
+## rpc.client.connection_pool(buffer)_size * "# of storage nodes + # of manager nodes in your cluster"
+## The default value is suitable for less than 16 nodes in a cluster
+## rpc.server.acceptors = 128
+
+## RPC-Server's listening port number
+rpc.server.listen_port = 13079
+
+## RPC-Server's listening timeout
+## rpc.server.listen_timeout = 30000
+
+## RPC-Client's size of connection pool
+## rpc.client.connection_pool_size = 8
+
+## RPC-Client's size of connection buffer
+## rpc.client.connection_buffer_size = 8
+
+## RPC-Client's max number of requests for reconnection to a remote-node
+## * 1..<integer>: specialized value
+## rpc.client.max_requests_for_reconnection = 64
+
+
+## --------------------------------------------------------------------
+## MANAGER - Mnesia
+##     * Store the info storage-cluster and the info of gateway(s)
+##     * Store the RING and the command histories
+## --------------------------------------------------------------------
+## The write threshold for transaction log dumps
+## as the number of writes to the transaction log
+mnesia.dump_log_write_threshold = 50000
+
+## Controls how often disc_copies tables are dumped from memory
+mnesia.dc_dump_limit = 40
+
+## --------------------------------------------------------------------
+## Profiling
+## --------------------------------------------------------------------
+## Enable profiler - leo_backend_db
+## leo_backend_db.profile = false
+
+## Enable profiler - leo_logger
+## leo_logger.profile = false
+
+## Enable profiler - leo_mq
+## leo_mq.profile = false
+
+## Enable profiler - leo_object_storage
+## leo_object_storage.profile = false
+
+## Enable profiler - leo_ordning_reda
+## leo_ordning_reda.profile = false
+
+## Enable profiler - leo_redundant_manager
+## leo_redundant_manager.profile = false
+
+## Enable profiler - leo_rpc
+## leo_rpc.profile = false
+
+## Enable profiler - leo_statistics
+## leo_statistics.profile = false
+
+
+##======================================================================
+## For vm.args
+##======================================================================
+## Name of the leofs-storage node
+nodename = storage_2@127.0.0.1
+
+## Cookie for distributed node communication.  All nodes in the same cluster
+## should use the same cookie or they will not be able to communicate.
+distributed_cookie = 401321b4
+
+## Enable kernel poll
+erlang.kernel_poll = true
+
+## Number of async threads
+erlang.async_threads = 32
+
+## Increase number of concurrent ports/sockets
+erlang.max_ports = 64000
+
+## Set the location of crash dumps
+erlang.crash_dump = ./log/erl_crash.dump
+
+## Raise the ETS table limit
+erlang.max_ets_tables = 256000
+
+## Enable SMP
+erlang.smp = enable
+
+## Erlang scheduler's compaction of load
+erlang.schedulers.compaction_of_load = true
+
+## Erlang scheduler's balancing of load
+erlang.schedulers.utilization_balancing = false
+
+## Sender-side network distribution buffer size
+## - default 32MB (32768KB)
+erlang.distribution_buffer_size = 32768
+
+## A non-negative integer which indicates
+## how many times generational garbage collections
+## can be done without forcing a fullsweep collection
+erlang.fullsweep_after = 0
+
+## Enable/Disable eager check I/O (Erlang 17.4/erts-6.3-, ref:OTP-12117)
+erlang.secio = false
+
+## Raise the default erlang process limit
+process_limit = 1048576
+
+## Path of SNMP-agent configuration
+snmp_conf = ./snmp/snmpa_storage_2/leo_storage_snmp

--- a/priv/test/rack-awareness-test/app-s3.conf
+++ b/priv/test/rack-awareness-test/app-s3.conf
@@ -1,0 +1,423 @@
+##======================================================================
+## LeoFS - Storage Configuration
+##
+## See: http://leo-project.net/leofs/docs/configuration/configuration_2.html
+##======================================================================
+## --------------------------------------------------------------------
+## SASL
+## --------------------------------------------------------------------
+## See: http://www.erlang.org/doc/man/sasl_app.html
+##
+## The following configuration parameters are defined for
+## the SASL application. See app(4) for more information
+## about configuration parameters
+
+## SASL error log path
+## sasl.sasl_error_log = ./log/sasl/sasl-error.log
+
+## Restricts the error logging performed by the specified sasl_error_logger
+## to error reports, progress reports, or both.
+## errlog_type = [error | progress | all]
+## sasl.errlog_type = error
+
+## Specifies in which directory the files are stored.
+## If this parameter is undefined or false, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_dir = ./log/sasl
+
+## Specifies how large each individual file can be.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxbytes = 10485760
+
+## Specifies how many files are used.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxfiles = 5
+
+## --------------------------------------------------------------------
+## Manager's Node(s)
+## --------------------------------------------------------------------
+## Name of Manager node(s)
+managers = [manager_0@127.0.0.1, manager_1@127.0.0.1]
+
+## --------------------------------------------------------------------
+## STORAGE
+## --------------------------------------------------------------------
+## Object container
+obj_containers.path = [./avs]
+obj_containers.num_of_containers = [8]
+
+## e.g. Case of plural pathes
+## obj_containers.path = [/var/leofs/avs/1, /var/leofs/avs/2]
+## obj_containers.num_of_containers = [32, 64]
+
+## Metadata Storage: [bitcask, leveldb] - default:leveldb
+## obj_containers.metadata_storage = leveldb
+
+## A number of virtual-nodes for the redundant-manager
+## num_of_vnodes = 168
+
+## Enable strict check between checksum of a metadata and checksum of an object
+## - default:false
+## object_storage.is_strict_check = false
+
+## Threshold of slow processing (msec) - default:1000(msec)
+## object_storage.threshold_of_slow_processing = 1000
+
+## Maximum number of processes for both write and read operation
+## since v1.2.20
+max_num_of_procs = 3000
+
+## Total number of obj-storage-read processes per object-container, AVS
+## Range: [1..100]
+## since v1.2.20
+num_of_obj_storage_read_procs = 3
+
+
+## --------------------------------------------------------------------
+## STORAGE - Watchdog
+## --------------------------------------------------------------------
+## When reach a number of safe (clear watchdog), a watchdog loosen the control
+watchdog.common.loosen_control_at_safe_count = 1
+
+##
+##  Watchdog.REX(RPC)
+##
+## Is rex-watchdog enabled - default:false
+watchdog.rex.is_enabled = true
+
+## rex - watch interval - default:5sec
+watchdog.rex.interval = 10
+
+## Threshold memory capacity of binary for rex(rpc) - default:32MB
+watchdog.rex.threshold_mem_capacity = 33554432
+
+
+##
+##  Watchdog.CPU
+##
+## Is cpu-watchdog enabled - default:false
+watchdog.cpu.is_enabled = false
+
+## cpu - raised error times
+watchdog.cpu.raised_error_times = 5
+
+## cpu - watch interval - default:5sec
+watchdog.cpu.interval = 10
+
+## Threshold CPU load avg for 1min/5min - default:5.0
+watchdog.cpu.threshold_cpu_load_avg = 5.0
+
+## Threshold CPU load util - default:100 = "100%"
+watchdog.cpu.threshold_cpu_util = 100
+
+##
+##  Watchdog.DISK
+##
+## Is disk-watchdog enabled - default:false
+watchdog.disk.is_enabled = false
+
+## disk - raised error times
+watchdog.disk.raised_error_times = 5
+
+## disk - watch interval - default:1sec
+watchdog.disk.interval = 10
+
+## Threshold use(%) of a target disk's capacity - defalut:85%
+watchdog.disk.threshold_disk_use = 85
+
+## Threshold disk utilization(%) - defalut:90%
+watchdog.disk.threshold_disk_util = 90
+
+## Threshold disk read kb/sec - defalut:98304(KB) = 96MB
+watchdog.disk.threshold_disk_rkb = 98304
+
+## Threshold disk write kb/sec - defalut:98304(KB) = 96MB
+watchdog.disk.threshold_disk_wkb = 98304
+
+## disk target devices for checking disk utilization
+## watchdog.disk.target_devices = []
+
+##
+##  Watchdog.Cluster
+##
+## Is cluster-watchdog enabled - default:false
+watchdog.cluster.is_enabled = false
+
+## cluster - watch interval - default:10sec
+watchdog.cluster.interval = 10
+
+##
+##  Watchdog.Error
+##
+## Is error-watchdog enabled - default:false
+watchdog.error.is_enabled = false
+
+## error - watch interval - default:60sec
+watchdog.error.interval = 60
+
+## error - threshold error count - default:100
+watchdog.error.threshold_count = 100
+
+
+## --------------------------------------------------------------------
+## STORAGE - Autonomic Operation
+## --------------------------------------------------------------------
+## [compaction] enabled compaction? - default:false
+autonomic_op.compaction.is_enabled = false
+
+## [compaction] number of parallel procs - default:1
+autonomic_op.compaction.parallel_procs = 1
+
+## [compaction] execution intarval time(sec) - default:3600(sec) (60min)
+autonomic_op.compaction.interval = 3600
+
+## [compaction] warning ratio of active size - default:70%
+autonomic_op.compaction.warn_active_size_ratio = 70
+
+## [compaction] threshold ratio of active size - default:60%
+autonomic_op.compaction.threshold_active_size_ratio = 60
+
+
+## --------------------------------------------------------------------
+## STORAGE - Data Compcation
+## --------------------------------------------------------------------
+## Limit of a number of procs to execute data-compaction in parallel
+compaction.limit_num_of_compaction_procs = 4
+
+## Regular value of compaction-proc waiting time/batch-proc(msec)
+compaction.waiting_time_regular = 500
+
+## Maximum value of compaction-proc waiting time/batch-proc(msec)
+compaction.waiting_time_max = 3000
+
+
+## Regular compaction batch processes
+compaction.batch_procs_regular = 1000
+
+## Maximum compaction batch processes
+compaction.batch_procs_max = 1500
+
+
+## --------------------------------------------------------------------
+## STORAGE - MQ
+## --------------------------------------------------------------------
+## MQ backend storage: [bitcask] - default:bitcask
+mq.backend_db = leveldb
+
+## A number of mq-server's processes
+mq.num_of_mq_procs = 8
+
+##
+## [Number of bach processes of message]
+##
+## Maximum number of bach processes of message
+mq.num_of_batch_process_max = 3000
+
+## Regular value of bach processes of message
+mq.num_of_batch_process_regular = 1600
+
+##
+## [Interval beween batch-procs]
+##
+## Maximum value of interval between batch-procs(msec)
+mq.interval_between_batch_procs_max = 3000
+
+## Regular value of interval between batch-procs(msec)
+mq.interval_between_batch_procs_regular = 500
+
+
+## --------------------------------------------------------------------
+## STORAGE - Replication/Recovery object(s)
+## --------------------------------------------------------------------
+## Rack-id for the rack-awareness replica placement
+replication.rack_awareness.rack_id = rack_2
+
+## Size of stacked objects (bytes)
+## replication.recovery.size_of_stacked_objs = 33554432
+
+## Stacking timeout (sec)
+## replication.recovery.stacking_timeout = 5
+
+
+## --------------------------------------------------------------------
+## STORAGE - MDC Replication
+## --------------------------------------------------------------------
+## Size of stacked objects (bytes) - default:32MB
+mdc_replication.size_of_stacked_objs = 33554432
+
+## Stacking timeout (sec)
+mdc_replication.stacking_timeout = 30
+
+## Request timeout (msec)
+mdc_replication.req_timeout = 30000
+
+## Number of stacking procs
+mdc_replication.stacking_procs = 1
+
+
+## --------------------------------------------------------------------
+## STORAGE - Log
+## --------------------------------------------------------------------
+## Log level: [0:debug, 1:info, 2:warn, 3:error]
+log.log_level = 1
+
+## Is enable access-log [true, false]
+log.is_enable_access_log = true
+
+## Access log's level
+##   - 0: only regular case
+##   - 1: includes error cases
+log.access_log_level = 0
+
+## Output log file(s) - Erlang's log
+## log.erlang = ./log/erlang
+
+## Output log file(s) - app
+## log.app = ./log/app
+
+## Output log file(s) - members of storage-cluster
+## log.member_dir = ./log/ring
+
+## Output log file(s) - ring
+## log.ring_dir = ./log/ring
+
+## Output data-diagnosis log
+log.is_enable_diagnosis_log = true
+
+## --------------------------------------------------------------------
+## STORAGE - Other Directories
+## --------------------------------------------------------------------
+## Directory of queue for monitoring "RING"
+## queue_dir  = ./work/queue
+
+## Directory of SNMP agent configuration
+snmp_agent = ./snmp/snmpa_storage_3/LEO-STORAGE
+
+
+## --------------------------------------------------------------------
+## Other Libs
+## --------------------------------------------------------------------
+## Send after interval
+## leo_ordning_reda.send_after_interval = 100
+
+## Temporary directory of stacked objects
+## leo_ordning_reda.temp_stacked_dir = "work/ord_reda/"
+
+
+## --------------------------------------------------------------------
+## RPC
+## --------------------------------------------------------------------
+## RPC-Server's acceptors
+## this value must be determinted by following logic
+## rpc.server.acceptor need to be larger than
+## rpc.client.connection_pool(buffer)_size * "# of storage nodes + # of manager nodes in your cluster"
+## The default value is suitable for less than 16 nodes in a cluster
+## rpc.server.acceptors = 128
+
+## RPC-Server's listening port number
+rpc.server.listen_port = 13080
+
+## RPC-Server's listening timeout
+## rpc.server.listen_timeout = 30000
+
+## RPC-Client's size of connection pool
+## rpc.client.connection_pool_size = 8
+
+## RPC-Client's size of connection buffer
+## rpc.client.connection_buffer_size = 8
+
+## RPC-Client's max number of requests for reconnection to a remote-node
+## * 1..<integer>: specialized value
+## rpc.client.max_requests_for_reconnection = 64
+
+
+## --------------------------------------------------------------------
+## MANAGER - Mnesia
+##     * Store the info storage-cluster and the info of gateway(s)
+##     * Store the RING and the command histories
+## --------------------------------------------------------------------
+## The write threshold for transaction log dumps
+## as the number of writes to the transaction log
+mnesia.dump_log_write_threshold = 50000
+
+## Controls how often disc_copies tables are dumped from memory
+mnesia.dc_dump_limit = 40
+
+## --------------------------------------------------------------------
+## Profiling
+## --------------------------------------------------------------------
+## Enable profiler - leo_backend_db
+## leo_backend_db.profile = false
+
+## Enable profiler - leo_logger
+## leo_logger.profile = false
+
+## Enable profiler - leo_mq
+## leo_mq.profile = false
+
+## Enable profiler - leo_object_storage
+## leo_object_storage.profile = false
+
+## Enable profiler - leo_ordning_reda
+## leo_ordning_reda.profile = false
+
+## Enable profiler - leo_redundant_manager
+## leo_redundant_manager.profile = false
+
+## Enable profiler - leo_rpc
+## leo_rpc.profile = false
+
+## Enable profiler - leo_statistics
+## leo_statistics.profile = false
+
+
+##======================================================================
+## For vm.args
+##======================================================================
+## Name of the leofs-storage node
+nodename = storage_3@127.0.0.1
+
+## Cookie for distributed node communication.  All nodes in the same cluster
+## should use the same cookie or they will not be able to communicate.
+distributed_cookie = 401321b4
+
+## Enable kernel poll
+erlang.kernel_poll = true
+
+## Number of async threads
+erlang.async_threads = 32
+
+## Increase number of concurrent ports/sockets
+erlang.max_ports = 64000
+
+## Set the location of crash dumps
+erlang.crash_dump = ./log/erl_crash.dump
+
+## Raise the ETS table limit
+erlang.max_ets_tables = 256000
+
+## Enable SMP
+erlang.smp = enable
+
+## Erlang scheduler's compaction of load
+erlang.schedulers.compaction_of_load = true
+
+## Erlang scheduler's balancing of load
+erlang.schedulers.utilization_balancing = false
+
+## Sender-side network distribution buffer size
+## - default 32MB (32768KB)
+erlang.distribution_buffer_size = 32768
+
+## A non-negative integer which indicates
+## how many times generational garbage collections
+## can be done without forcing a fullsweep collection
+erlang.fullsweep_after = 0
+
+## Enable/Disable eager check I/O (Erlang 17.4/erts-6.3-, ref:OTP-12117)
+erlang.secio = false
+
+## Raise the default erlang process limit
+process_limit = 1048576
+
+## Path of SNMP-agent configuration
+snmp_conf = ./snmp/snmpa_storage_3/leo_storage_snmp

--- a/priv/test/rack-awareness-test/app-s4.conf
+++ b/priv/test/rack-awareness-test/app-s4.conf
@@ -1,0 +1,423 @@
+##======================================================================
+## LeoFS - Storage Configuration
+##
+## See: http://leo-project.net/leofs/docs/configuration/configuration_2.html
+##======================================================================
+## --------------------------------------------------------------------
+## SASL
+## --------------------------------------------------------------------
+## See: http://www.erlang.org/doc/man/sasl_app.html
+##
+## The following configuration parameters are defined for
+## the SASL application. See app(4) for more information
+## about configuration parameters
+
+## SASL error log path
+## sasl.sasl_error_log = ./log/sasl/sasl-error.log
+
+## Restricts the error logging performed by the specified sasl_error_logger
+## to error reports, progress reports, or both.
+## errlog_type = [error | progress | all]
+## sasl.errlog_type = error
+
+## Specifies in which directory the files are stored.
+## If this parameter is undefined or false, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_dir = ./log/sasl
+
+## Specifies how large each individual file can be.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxbytes = 10485760
+
+## Specifies how many files are used.
+## If this parameter is undefined, the error_logger_mf_h is not installed.
+## sasl.error_logger_mf_maxfiles = 5
+
+## --------------------------------------------------------------------
+## Manager's Node(s)
+## --------------------------------------------------------------------
+## Name of Manager node(s)
+managers = [manager_0@127.0.0.1, manager_1@127.0.0.1]
+
+## --------------------------------------------------------------------
+## STORAGE
+## --------------------------------------------------------------------
+## Object container
+obj_containers.path = [./avs]
+obj_containers.num_of_containers = [8]
+
+## e.g. Case of plural pathes
+## obj_containers.path = [/var/leofs/avs/1, /var/leofs/avs/2]
+## obj_containers.num_of_containers = [32, 64]
+
+## Metadata Storage: [bitcask, leveldb] - default:leveldb
+## obj_containers.metadata_storage = leveldb
+
+## A number of virtual-nodes for the redundant-manager
+## num_of_vnodes = 168
+
+## Enable strict check between checksum of a metadata and checksum of an object
+## - default:false
+## object_storage.is_strict_check = false
+
+## Threshold of slow processing (msec) - default:1000(msec)
+## object_storage.threshold_of_slow_processing = 1000
+
+## Maximum number of processes for both write and read operation
+## since v1.2.20
+max_num_of_procs = 3000
+
+## Total number of obj-storage-read processes per object-container, AVS
+## Range: [1..100]
+## since v1.2.20
+num_of_obj_storage_read_procs = 3
+
+
+## --------------------------------------------------------------------
+## STORAGE - Watchdog
+## --------------------------------------------------------------------
+## When reach a number of safe (clear watchdog), a watchdog loosen the control
+watchdog.common.loosen_control_at_safe_count = 1
+
+##
+##  Watchdog.REX(RPC)
+##
+## Is rex-watchdog enabled - default:false
+watchdog.rex.is_enabled = true
+
+## rex - watch interval - default:5sec
+watchdog.rex.interval = 10
+
+## Threshold memory capacity of binary for rex(rpc) - default:32MB
+watchdog.rex.threshold_mem_capacity = 33554432
+
+
+##
+##  Watchdog.CPU
+##
+## Is cpu-watchdog enabled - default:false
+watchdog.cpu.is_enabled = false
+
+## cpu - raised error times
+watchdog.cpu.raised_error_times = 5
+
+## cpu - watch interval - default:5sec
+watchdog.cpu.interval = 10
+
+## Threshold CPU load avg for 1min/5min - default:5.0
+watchdog.cpu.threshold_cpu_load_avg = 5.0
+
+## Threshold CPU load util - default:100 = "100%"
+watchdog.cpu.threshold_cpu_util = 100
+
+##
+##  Watchdog.DISK
+##
+## Is disk-watchdog enabled - default:false
+watchdog.disk.is_enabled = false
+
+## disk - raised error times
+watchdog.disk.raised_error_times = 5
+
+## disk - watch interval - default:1sec
+watchdog.disk.interval = 10
+
+## Threshold use(%) of a target disk's capacity - defalut:85%
+watchdog.disk.threshold_disk_use = 85
+
+## Threshold disk utilization(%) - defalut:90%
+watchdog.disk.threshold_disk_util = 90
+
+## Threshold disk read kb/sec - defalut:98304(KB) = 96MB
+watchdog.disk.threshold_disk_rkb = 98304
+
+## Threshold disk write kb/sec - defalut:98304(KB) = 96MB
+watchdog.disk.threshold_disk_wkb = 98304
+
+## disk target devices for checking disk utilization
+## watchdog.disk.target_devices = []
+
+##
+##  Watchdog.Cluster
+##
+## Is cluster-watchdog enabled - default:false
+watchdog.cluster.is_enabled = false
+
+## cluster - watch interval - default:10sec
+watchdog.cluster.interval = 10
+
+##
+##  Watchdog.Error
+##
+## Is error-watchdog enabled - default:false
+watchdog.error.is_enabled = false
+
+## error - watch interval - default:60sec
+watchdog.error.interval = 60
+
+## error - threshold error count - default:100
+watchdog.error.threshold_count = 100
+
+
+## --------------------------------------------------------------------
+## STORAGE - Autonomic Operation
+## --------------------------------------------------------------------
+## [compaction] enabled compaction? - default:false
+autonomic_op.compaction.is_enabled = false
+
+## [compaction] number of parallel procs - default:1
+autonomic_op.compaction.parallel_procs = 1
+
+## [compaction] execution intarval time(sec) - default:3600(sec) (60min)
+autonomic_op.compaction.interval = 3600
+
+## [compaction] warning ratio of active size - default:70%
+autonomic_op.compaction.warn_active_size_ratio = 70
+
+## [compaction] threshold ratio of active size - default:60%
+autonomic_op.compaction.threshold_active_size_ratio = 60
+
+
+## --------------------------------------------------------------------
+## STORAGE - Data Compcation
+## --------------------------------------------------------------------
+## Limit of a number of procs to execute data-compaction in parallel
+compaction.limit_num_of_compaction_procs = 4
+
+## Regular value of compaction-proc waiting time/batch-proc(msec)
+compaction.waiting_time_regular = 500
+
+## Maximum value of compaction-proc waiting time/batch-proc(msec)
+compaction.waiting_time_max = 3000
+
+
+## Regular compaction batch processes
+compaction.batch_procs_regular = 1000
+
+## Maximum compaction batch processes
+compaction.batch_procs_max = 1500
+
+
+## --------------------------------------------------------------------
+## STORAGE - MQ
+## --------------------------------------------------------------------
+## MQ backend storage: [bitcask] - default:bitcask
+mq.backend_db = leveldb
+
+## A number of mq-server's processes
+mq.num_of_mq_procs = 8
+
+##
+## [Number of bach processes of message]
+##
+## Maximum number of bach processes of message
+mq.num_of_batch_process_max = 3000
+
+## Regular value of bach processes of message
+mq.num_of_batch_process_regular = 1600
+
+##
+## [Interval beween batch-procs]
+##
+## Maximum value of interval between batch-procs(msec)
+mq.interval_between_batch_procs_max = 3000
+
+## Regular value of interval between batch-procs(msec)
+mq.interval_between_batch_procs_regular = 500
+
+
+## --------------------------------------------------------------------
+## STORAGE - Replication/Recovery object(s)
+## --------------------------------------------------------------------
+## Rack-id for the rack-awareness replica placement
+replication.rack_awareness.rack_id = rack_2
+
+## Size of stacked objects (bytes)
+## replication.recovery.size_of_stacked_objs = 33554432
+
+## Stacking timeout (sec)
+## replication.recovery.stacking_timeout = 5
+
+
+## --------------------------------------------------------------------
+## STORAGE - MDC Replication
+## --------------------------------------------------------------------
+## Size of stacked objects (bytes) - default:32MB
+mdc_replication.size_of_stacked_objs = 33554432
+
+## Stacking timeout (sec)
+mdc_replication.stacking_timeout = 30
+
+## Request timeout (msec)
+mdc_replication.req_timeout = 30000
+
+## Number of stacking procs
+mdc_replication.stacking_procs = 1
+
+
+## --------------------------------------------------------------------
+## STORAGE - Log
+## --------------------------------------------------------------------
+## Log level: [0:debug, 1:info, 2:warn, 3:error]
+log.log_level = 1
+
+## Is enable access-log [true, false]
+log.is_enable_access_log = true
+
+## Access log's level
+##   - 0: only regular case
+##   - 1: includes error cases
+log.access_log_level = 0
+
+## Output log file(s) - Erlang's log
+## log.erlang = ./log/erlang
+
+## Output log file(s) - app
+## log.app = ./log/app
+
+## Output log file(s) - members of storage-cluster
+## log.member_dir = ./log/ring
+
+## Output log file(s) - ring
+## log.ring_dir = ./log/ring
+
+## Output data-diagnosis log
+log.is_enable_diagnosis_log = true
+
+## --------------------------------------------------------------------
+## STORAGE - Other Directories
+## --------------------------------------------------------------------
+## Directory of queue for monitoring "RING"
+## queue_dir  = ./work/queue
+
+## Directory of SNMP agent configuration
+snmp_agent = ./snmp/snmpa_storage_3/LEO-STORAGE
+
+
+## --------------------------------------------------------------------
+## Other Libs
+## --------------------------------------------------------------------
+## Send after interval
+## leo_ordning_reda.send_after_interval = 100
+
+## Temporary directory of stacked objects
+## leo_ordning_reda.temp_stacked_dir = "work/ord_reda/"
+
+
+## --------------------------------------------------------------------
+## RPC
+## --------------------------------------------------------------------
+## RPC-Server's acceptors
+## this value must be determinted by following logic
+## rpc.server.acceptor need to be larger than
+## rpc.client.connection_pool(buffer)_size * "# of storage nodes + # of manager nodes in your cluster"
+## The default value is suitable for less than 16 nodes in a cluster
+## rpc.server.acceptors = 128
+
+## RPC-Server's listening port number
+rpc.server.listen_port = 13081
+
+## RPC-Server's listening timeout
+## rpc.server.listen_timeout = 30000
+
+## RPC-Client's size of connection pool
+## rpc.client.connection_pool_size = 8
+
+## RPC-Client's size of connection buffer
+## rpc.client.connection_buffer_size = 8
+
+## RPC-Client's max number of requests for reconnection to a remote-node
+## * 1..<integer>: specialized value
+## rpc.client.max_requests_for_reconnection = 64
+
+
+## --------------------------------------------------------------------
+## MANAGER - Mnesia
+##     * Store the info storage-cluster and the info of gateway(s)
+##     * Store the RING and the command histories
+## --------------------------------------------------------------------
+## The write threshold for transaction log dumps
+## as the number of writes to the transaction log
+mnesia.dump_log_write_threshold = 50000
+
+## Controls how often disc_copies tables are dumped from memory
+mnesia.dc_dump_limit = 40
+
+## --------------------------------------------------------------------
+## Profiling
+## --------------------------------------------------------------------
+## Enable profiler - leo_backend_db
+## leo_backend_db.profile = false
+
+## Enable profiler - leo_logger
+## leo_logger.profile = false
+
+## Enable profiler - leo_mq
+## leo_mq.profile = false
+
+## Enable profiler - leo_object_storage
+## leo_object_storage.profile = false
+
+## Enable profiler - leo_ordning_reda
+## leo_ordning_reda.profile = false
+
+## Enable profiler - leo_redundant_manager
+## leo_redundant_manager.profile = false
+
+## Enable profiler - leo_rpc
+## leo_rpc.profile = false
+
+## Enable profiler - leo_statistics
+## leo_statistics.profile = false
+
+
+##======================================================================
+## For vm.args
+##======================================================================
+## Name of the leofs-storage node
+nodename = storage_4@127.0.0.1
+
+## Cookie for distributed node communication.  All nodes in the same cluster
+## should use the same cookie or they will not be able to communicate.
+distributed_cookie = 401321b4
+
+## Enable kernel poll
+erlang.kernel_poll = true
+
+## Number of async threads
+erlang.async_threads = 32
+
+## Increase number of concurrent ports/sockets
+erlang.max_ports = 64000
+
+## Set the location of crash dumps
+erlang.crash_dump = ./log/erl_crash.dump
+
+## Raise the ETS table limit
+erlang.max_ets_tables = 256000
+
+## Enable SMP
+erlang.smp = enable
+
+## Erlang scheduler's compaction of load
+erlang.schedulers.compaction_of_load = true
+
+## Erlang scheduler's balancing of load
+erlang.schedulers.utilization_balancing = false
+
+## Sender-side network distribution buffer size
+## - default 32MB (32768KB)
+erlang.distribution_buffer_size = 32768
+
+## A non-negative integer which indicates
+## how many times generational garbage collections
+## can be done without forcing a fullsweep collection
+erlang.fullsweep_after = 0
+
+## Enable/Disable eager check I/O (Erlang 17.4/erts-6.3-, ref:OTP-12117)
+erlang.secio = false
+
+## Raise the default erlang process limit
+process_limit = 1048576
+
+## Path of SNMP-agent configuration
+snmp_conf = ./snmp/snmpa_storage_4/leo_storage_snmp


### PR DESCRIPTION
To be able to recognize `rack-id` of each LeoStorage on the console _(leofs-adm)_, I've modified `status [<node>]` command:

* Issue: leo-project/leofs/issues/1047

## Text
### sample output of `leofs-adm status`

```
 [System Confiuration]
-----------------------------------+----------
 Item                              | Value
-----------------------------------+----------
 Basic/Consistency level
-----------------------------------+----------
                    system version | 1.4.1
                        cluster Id | leofs_1
                             DC Id | dc_1
                    Total replicas | 3
          number of successes of R | 1
          number of successes of W | 2
          number of successes of D | 2
 number of rack-awareness replicas | 2
                         ring size | 2^128
-----------------------------------+----------
 Multi DC replication settings
-----------------------------------+----------
 [mdcr] max number of joinable DCs | 2
 [mdcr] total replicas per a DC    | 1
 [mdcr] number of successes of R   | 1
 [mdcr] number of successes of W   | 1
 [mdcr] number of successes of D   | 1
-----------------------------------+----------
 Manager RING hash
-----------------------------------+----------
                 current ring-hash | a08aab77
                previous ring-hash | a08aab77
-----------------------------------+----------

 [State of Node(s)]
-------+--------------------------+--------------+---------------+----------------+----------------+----------------------------
 type  |           node           |    state     |    rack id    |  current ring  |   prev ring    |          updated at
-------+--------------------------+--------------+---------------+----------------+----------------+----------------------------
  S    | storage_0@127.0.0.1      | running      | rack_1        | a08aab77       | a08aab77       | 2018-06-04 22:13:18 +0900
  S    | storage_1@127.0.0.1      | running      | rack_1        | a08aab77       | a08aab77       | 2018-06-04 22:13:18 +0900
  S    | storage_2@127.0.0.1      | running      | rack_2        | a08aab77       | a08aab77       | 2018-06-04 22:13:18 +0900
  S    | storage_3@127.0.0.1      | running      | rack_2        | a08aab77       | a08aab77       | 2018-06-04 22:13:18 +0900
  G    | gateway_0@127.0.0.1      | running      |               | a08aab77       | a08aab77       | 2018-06-04 22:13:17 +0900
-------+--------------------------+--------------+---------------+----------------+----------------+----------------------------

```

### sample output of `leofs-adm status <node>`

```
--------------------------------------+--------------------------------------
                Item                  |                 Value
--------------------------------------+--------------------------------------
 Config-1: basic
--------------------------------------+--------------------------------------
                              version | 1.4.0
                     number of vnodes | 168
                      rack id (group) | rack_1
                    object containers | - path:[./avs], # of containers:8
                        log directory | ./log/erlang
                            log level | info
--------------------------------------+--------------------------------------
 Config-2: watchdog
--------------------------------------+--------------------------------------
 [rex(rpc-proc)]                      |
                    check interval(s) | 10
               threshold mem capacity | 33554432
--------------------------------------+--------------------------------------
 [cpu]                                |
                     enabled/disabled | disabled
                    check interval(s) | 10
               threshold cpu load avg | 5.0
                threshold cpu util(%) | 100
--------------------------------------+--------------------------------------
 [disk]                               |
                     enabled/disalbed | disabled
                    check interval(s) | 10
                threshold disk use(%) | 85
               threshold disk util(%) | 90
                    threshold rkb(kb) | 98304
                    threshold wkb(kb) | 98304
--------------------------------------+--------------------------------------
 Config-3: message-queue
--------------------------------------+--------------------------------------
                   number of procs/mq | 8
        number of batch-procs of msgs | max:3000, regular:1600
   interval between batch-procs (ms)  | max:3000, regular:500
--------------------------------------+--------------------------------------
 Config-4: autonomic operation
--------------------------------------+--------------------------------------
 [auto-compaction]                    |
                     enabled/disabled | disabled
        warning active size ratio (%) | 70
      threshold active size ratio (%) | 60
             number of parallel procs | 1
                        exec interval | 3600
--------------------------------------+--------------------------------------
 Config-5: data-compaction
--------------------------------------+--------------------------------------
  limit of number of compaction procs | 4
        number of batch-procs of objs | max:1500, regular:1000
   interval between batch-procs (ms)  | max:3000, regular:500
--------------------------------------+--------------------------------------
 Status-1: RING hash
--------------------------------------+--------------------------------------
                    current ring hash | a08aab77
                   previous ring hash | a08aab77
--------------------------------------+--------------------------------------
 Status-2: Erlang VM
--------------------------------------+--------------------------------------
                           vm version | 9.3
                      total mem usage | 48167024
                     system mem usage | 25366384
                      procs mem usage | 22803272
                        ets mem usage | 4134584
                                procs | 776/1048576
                          kernel_poll | true
                     thread_pool_size | 32
--------------------------------------+--------------------------------------
 Status-3: Number of messages in MQ
--------------------------------------+--------------------------------------
                 replication messages | 0
                  vnode-sync messages | 0
                   rebalance messages | 0
--------------------------------------+--------------------------------------
```

## JSON
### sample output of `leofs-adm status`
 
```js
{
  "system_info": {
    "version": "1.4.1",
    "cluster_id": "leofs_1",
    "dc_id": "dc_1",
    "n": 3,
    "r": 1,
    "w": 2,
    "d": 2,
    "dc_awareness_replicas": 1,
    "mdcr_n": 1,
    "mdcr_r": 1,
    "mdcr_w": 1,
    "mdcr_d": 1,
    "rack_awareness_replicas": 2,
    "ring_size": 128,
    "ring_hash_cur": 2693442423,
    "ring_hash_prev": 2693442423,
    "max_mdc_targets": 2
  },
  "node_list": [
    {
      "type": "S",
      "node": "storage_0@127.0.0.1",
      "state": "running",
      "rack_id": "rack_1",
      "ring_cur": "a08aab77",
      "ring_prev": "a08aab77",
      "when": "2018-06-04 22:13:18 +0900"
    },
    {
      "type": "S",
      "node": "storage_1@127.0.0.1",
      "state": "running",
      "rack_id": "rack_1",
      "ring_cur": "a08aab77",
      "ring_prev": "a08aab77",
      "when": "2018-06-04 22:13:18 +0900"
    },
    {
      "type": "S",
      "node": "storage_2@127.0.0.1",
      "state": "running",
      "rack_id": "rack_2",
      "ring_cur": "a08aab77",
      "ring_prev": "a08aab77",
      "when": "2018-06-04 22:13:18 +0900"
    },
    {
      "type": "S",
      "node": "storage_3@127.0.0.1",
      "state": "running",
      "rack_id": "rack_2",
      "ring_cur": "a08aab77",
      "ring_prev": "a08aab77",
      "when": "2018-06-04 22:13:18 +0900"
    },
    {
      "type": "G",
      "node": "gateway_0@127.0.0.1",
      "state": "running",
      "rack_id": "",
      "ring_cur": "a08aab77",
      "ring_prev": "a08aab77",
      "when": "2018-06-04 22:13:17 +0900"
    }
  ]
}
```

### sample output of `leofs-adm status <node>`

```js
{
  "node_stat": {
    "version": "1.4.0",
    "num_of_vnodes": 168,
    "grp_level_2": "rack_1",
    "rack_id": "rack_1",
    "log_dir": "./log/erlang",
    "ring_cur": "a08aab77",
    "ring_prev": "a08aab77",
    "vm_version": "9.3",
    "total_mem_usage": 47998912,
    "system_mem_usage": 25372160,
    "procs_mem_usage": 22649896,
    "ets_mem_usage": 4148600,
    "num_of_procs": 776,
    "limit_of_procs": 1048576,
    "kernel_poll": "true",
    "thread_pool_size": 32,
    "replication_msgs": 0,
    "sync_vnode_msgs": 0,
    "rebalance_msgs": 0,
    "wd_rex_interval": 10,
    "wd_rex_threshold_mem_capacity": 33554432,
    "wd_cpu_enabled": "disabled",
    "wd_cpu_interval": 10,
    "wd_cpu_threshold_cpu_load_avg": 5,
    "wd_cpu_threshold_cpu_util": 100,
    "wd_disk_enabled": "disabled",
    "wd_disk_interval": 10,
    "wd_disk_threshold_disk_use": "undefined",
    "wd_disk_threshold_disk_util": "undefined",
    "mq_num_of_procs": 8,
    "mq_num_of_batch_process_max": 3000,
    "mq_num_of_batch_process_reg": 1600,
    "mq_interval_between_batch_procs_max": 3000,
    "mq_interval_between_batch_procs_reg": 500,
    "auto_compaction_enabled": "disabled",
    "auto_compaction_warn_active_size_ratio": 70,
    "auto_compaction_threshold_active_size_ratio": 60,
    "auto_compaction_parallel_procs": 1,
    "auto_compaction_interval": 3600,
    "limit_num_of_compaction_procs": 4,
    "compaction_num_of_batch_procs_max": 1500,
    "compaction_num_of_batch_procs_reg": 1000,
    "compaction_interval_between_batch_procs_max": 3000,
    "compaction_interval_between_batch_procs_reg": 500
  }
}
```
