### PR TITLE
Fixed for Issue#1093

### DIFF
--- a/apps/leo_storage/rel/reltool.config
+++ b/apps/leo_storage/rel/reltool.config
@@ -3,7 +3,7 @@
 %%
 %% LeoFS Storage
 %%
-%% Copyright (c) 2012-2014 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/rel/vars.config
+++ b/apps/leo_storage/rel/vars.config
@@ -3,7 +3,7 @@
 %%
 %% LeoFS Storage
 %%
-%% Copyright (c) 2012-2014 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_api.erl
+++ b/apps/leo_storage/src/leo_storage_api.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_cluster_monitor.erl
+++ b/apps/leo_storage/src/leo_storage_cluster_monitor.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_handler_del_directory.erl
+++ b/apps/leo_storage/src/leo_storage_handler_del_directory.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_handler_directory.erl
+++ b/apps/leo_storage/src/leo_storage_handler_directory.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_handler_object.erl
+++ b/apps/leo_storage/src/leo_storage_handler_object.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_handler_sync.erl
+++ b/apps/leo_storage/src/leo_storage_handler_sync.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_msg_collector.erl
+++ b/apps/leo_storage/src/leo_storage_msg_collector.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_read_repairer.erl
+++ b/apps/leo_storage/src/leo_storage_read_repairer.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2016 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_replicator.erl
+++ b/apps/leo_storage/src/leo_storage_replicator.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2016 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_sup.erl
+++ b/apps/leo_storage/src/leo_storage_sup.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_watchdog_error.erl
+++ b/apps/leo_storage/src/leo_storage_watchdog_error.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_watchdog_fragment.erl
+++ b/apps/leo_storage/src/leo_storage_watchdog_fragment.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_watchdog_msgs.erl
+++ b/apps/leo_storage/src/leo_storage_watchdog_msgs.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_storage_watchdog_sub.erl
+++ b/apps/leo_storage/src/leo_storage_watchdog_sub.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_sync_local_cluster.erl
+++ b/apps/leo_storage/src/leo_sync_local_cluster.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/src/leo_sync_remote_cluster.erl
+++ b/apps/leo_storage/src/leo_sync_remote_cluster.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/test/basho_bench_driver_leo_storage.erl
+++ b/apps/leo_storage/test/basho_bench_driver_leo_storage.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012 - 2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/test/leo_storage_api_tests.erl
+++ b/apps/leo_storage/test/leo_storage_api_tests.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/test/leo_storage_handler_directory_tests.erl
+++ b/apps/leo_storage/test/leo_storage_handler_directory_tests.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/test/leo_storage_handler_object_tests.erl
+++ b/apps/leo_storage/test/leo_storage_handler_object_tests.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/test/leo_storage_mq_tests.erl
+++ b/apps/leo_storage/test/leo_storage_mq_tests.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/test/leo_storage_read_repairer_tests.erl
+++ b/apps/leo_storage/test/leo_storage_read_repairer_tests.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/test/leo_storage_replicator_tests.erl
+++ b/apps/leo_storage/test/leo_storage_replicator_tests.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/test/leo_sync_local_cluster_tests.erl
+++ b/apps/leo_storage/test/leo_sync_local_cluster_tests.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/apps/leo_storage/test/leo_sync_remote_cluster_tests.erl
+++ b/apps/leo_storage/test/leo_sync_remote_cluster_tests.erl
@@ -2,7 +2,7 @@
 %%
 %% LeoStorage
 %%
-%% Copyright (c) 2012-2017 Rakuten, Inc.
+%% Copyright (c) 2012-2018 Rakuten, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file


### PR DESCRIPTION
I've confirmed that LeoStorage is properly killing the process itself and output error-log when LeoManager nodes' IP address are incorrectly configured.

### Error Log:

```erlang
[E]	storage_0@127.0.0.1	2018-08-01 10:40:07.987204 +0900	1533087607
	leo_storage_app:after_proc/1	153
	[{cause,connection_failure},
	 {error_nodes,['manager_1@127.1.2.3']}]
```

* [Issue#1093](https://github.com/leo-project/leofs/issues/1093)