### PR TITLE
gateway: Fix #420 - Support GZIP Compression during network transfers

### DIFF
--- a/apps/leo_gateway/src/leo_gateway_http_commons.erl
+++ b/apps/leo_gateway/src/leo_gateway_http_commons.erl
@@ -102,6 +102,7 @@ start(#http_options{handler = Handler,
                  true ->
                      [{env, [{dispatch, Dispatch}]},
                       {max_keepalive, MaxKeepAlive},
+                      {compress, true},
                       {timeout, Timeout4Header}];
                  %% Using http-cache (like a varnish/squid)
                  false ->
@@ -112,6 +113,7 @@ start(#http_options{handler = Handler,
                                                        sending_chunked_obj_len = SendChunkLen},
                      [{env, [{dispatch, Dispatch}]},
                       {max_keepalive, MaxKeepAlive},
+                      {compress, true},
                       {onrequest, Handler:onrequest(CacheCondition)},
                       {onresponse, Handler:onresponse(CacheCondition)},
                       {timeout, Timeout4Header}]
@@ -335,6 +337,18 @@ do_health_check([#member{node = Node}|Rest]) ->
             do_health_check(Rest)
     end.
 
+-spec(can_gzip(cowboy_req:req()) ->
+             boolean()).
+can_gzip(Req) ->
+    try cowboy_req:parse_header(<<"accept-encoding">>, Req) of
+        {ok, Encodings, _Req} when is_list(Encodings) ->
+            false =/= lists:keyfind(<<"gzip">>, 1, Encodings);
+        _ ->
+            false
+    catch _:_ ->
+        false
+    end.
+
 %% @doc GET an object
 -spec(get_object(cowboy_req:req(), binary(), #req_params{}) ->
              {ok, cowboy_req:req()}).
@@ -387,13 +401,18 @@ get_object(Req, Key, #req_params{bucket_name = BucketName,
                                CMeta ++ Headers ++ CustomHeaders
                        end,
 
-            BodyFunc = fun(Socket, Transport) ->
-                               leo_net:chunked_send(
-                                 Transport, Socket, RespObject, SendChunkLen),
-                               ?access_log_get(BucketName, Key, Meta#?METADATA.dsize, ?HTTP_ST_OK, BeginTime)
-                       end,
-
-            ?reply_ok(Headers2, {Meta#?METADATA.dsize, BodyFunc}, Req);
+            case can_gzip(Req) of
+                true ->
+                    ?access_log_get(BucketName, Key, Meta#?METADATA.dsize, ?HTTP_ST_OK, BeginTime),
+                    ?reply_ok(Headers2, RespObject, Req);
+                false ->
+                    BodyFunc = fun(Socket, Transport) ->
+                                       leo_net:chunked_send(
+                                         Transport, Socket, RespObject, SendChunkLen),
+                                       ?access_log_get(BucketName, Key, Meta#?METADATA.dsize, ?HTTP_ST_OK, BeginTime)
+                               end,
+                    ?reply_ok(Headers2, {Meta#?METADATA.dsize, BodyFunc}, Req)
+            end;
 
         %% For a chunked object.
         {ok, #?METADATA{cnumber = TotalChunkedObjs,
@@ -539,13 +558,18 @@ get_object_with_cache(Req, Key, CacheObj, #req_params{bucket_name = BucketName,
                                CMeta ++ Headers ++ CustomHeaders
                        end,
 
-            BodyFunc = fun(Socket, Transport) ->
-                               leo_net:chunked_send(
-                                 Transport, Socket, CacheObj#cache.body, SendChunkLen),
-                               ?access_log_get(BucketName, Key, CacheObj#cache.size, ?HTTP_ST_OK, BeginTime, "hit:mem-cache")
-                       end,
-
-            ?reply_ok(Headers2, {CacheObj#cache.size, BodyFunc}, Req);
+            case can_gzip(Req) of
+                true ->
+                    ?access_log_get(BucketName, Key, CacheObj#cache.size, ?HTTP_ST_OK, BeginTime, "hit:mem-cache"),
+                    ?reply_ok(Headers2, CacheObj#cache.body, Req);
+                false ->
+                    BodyFunc = fun(Socket, Transport) ->
+                                       leo_net:chunked_send(
+                                         Transport, Socket, CacheObj#cache.body, SendChunkLen),
+                                       ?access_log_get(BucketName, Key, CacheObj#cache.size, ?HTTP_ST_OK, BeginTime, "hit:mem-cache")
+                               end,
+                    ?reply_ok(Headers2, {CacheObj#cache.size, BodyFunc}, Req)
+            end;
 
         %% MISS: For the case If-Modified-Since matches timestamp in metadata
         {ok, #?METADATA{timestamp = IMSSec}, _Resp} ->
@@ -576,13 +600,19 @@ get_object_with_cache(Req, Key, CacheObj, #req_params{bucket_name = BucketName,
                                CMeta = binary_to_term(CMetaBin),
                                CMeta ++ Headers ++ CustomHeaders
                        end,
-            BodyFunc = fun(Socket, Transport) ->
-                               leo_net:chunked_send(
-                                 Transport, Socket, RespObject, SendChunkLen)
-                       end,
 
-            ?access_log_get(BucketName, Key, Meta#?METADATA.dsize, ?HTTP_ST_OK, BeginTime),
-            ?reply_ok(Headers2, {Meta#?METADATA.dsize, BodyFunc}, Req);
+            case can_gzip(Req) of
+                true ->
+                    ?access_log_get(BucketName, Key, Meta#?METADATA.dsize, ?HTTP_ST_OK, BeginTime),
+                    ?reply_ok(Headers2, RespObject, Req);
+                false ->
+                    BodyFunc = fun(Socket, Transport) ->
+                                    leo_net:chunked_send(
+                                      Transport, Socket, RespObject, SendChunkLen),
+                                    ?access_log_get(BucketName, Key, Meta#?METADATA.dsize, ?HTTP_ST_OK, BeginTime)
+                               end,
+                    ?reply_ok(Headers2, {Meta#?METADATA.dsize, BodyFunc}, Req)
+            end;
 
         %% MISS: get an object from storage (large-size)
         {ok, #?METADATA{cnumber = TotalChunkedObjs,


### PR DESCRIPTION
Now adding the header "Accept-Encoding: gzip" to a GET request may make LeoFS respond the body compressed by gzip like below.

```bash
curl -v --compressed -D - -o rebar.gzip http://localhost:8080/test/rebar
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1...
* connect to ::1 port 8080 failed: Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /test/rebar HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.47.0
> Accept: */*
> Accept-Encoding: deflate, gzip
>
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Connection: keep-alive
Connection: keep-alive
< Date: Wed, 19 Sep 2018 07:54:21 GMT
Date: Wed, 19 Sep 2018 07:54:21 GMT
< Content-Encoding: gzip
Content-Encoding: gzip
< Content-Length: 174434
Content-Length: 174434
< x-amz-meta-s3cmd-attrs: uid:1001/gname:leofs/uname:leofs/gid:1001/mode:33277/mtime:1484807189/atime:1537320571/md5:3178fff900863cb8847d211a2dce053e/ctime:1484807189
x-amz-meta-s3cmd-attrs: uid:1001/gname:leofs/uname:leofs/gid:1001/mode:33277/mtime:1484807189/atime:1537320571/md5:3178fff900863cb8847d211a2dce053e/ctime:1484807189
< Server: LeoFS
Server: LeoFS
< Content-Type: application/octet-stream
Content-Type: application/octet-stream
< ETag: "3178fff900863cb8847d211a2dce053e"
ETag: "3178fff900863cb8847d211a2dce053e"
< Last-Modified: Wed, 19 Sep 2018 07:52:49 GMT
Last-Modified: Wed, 19 Sep 2018 07:52:49 GMT

<
{ [15947 bytes data]
100  170k  100  170k    0     0  8136k      0 --:--:-- --:--:-- --:--:-- 8517k
* Connection #0 to host localhost left intact
```
so users can reduce the bandwidth when downloading objects not compressed, stored in LeoFS.

This behavior can be applied to only small objects.